### PR TITLE
harness: tag episodic entries with active profile name

### DIFF
--- a/.agent/harness/hooks/_provenance.py
+++ b/.agent/harness/hooks/_provenance.py
@@ -5,6 +5,7 @@ AGENT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")
 
 _CACHED_COMMIT = None
 _CACHED_RUN_ID = None
+_CACHED_PROFILE = None
 
 
 def run_id():
@@ -12,6 +13,41 @@ def run_id():
     if _CACHED_RUN_ID is None:
         _CACHED_RUN_ID = os.environ.get("AGENT_RUN_ID", f"pid-{os.getpid()}")
     return _CACHED_RUN_ID
+
+
+def profile():
+    """Return the active harness profile name, or "default" when unknown.
+
+    Harnesses that run multiple isolated agent identities against the same
+    portable brain (e.g. Hermes's --profile flag spawning distinct
+    specialist agents) should set ``AGENT_PROFILE`` to the active name so
+    every episodic entry is tagged. Enables cross-profile clustering and
+    per-specialist retrospectives in the dream cycle.
+
+    Fallback detection covers known harnesses without code changes there:
+      * ``AGENT_PROFILE``  - canonical, any harness.
+      * ``HERMES_HOME``    - if it points under ``<...>/profiles/<name>``
+                             use that name; otherwise "default".
+    """
+    global _CACHED_PROFILE
+    if _CACHED_PROFILE is not None:
+        return _CACHED_PROFILE
+
+    explicit = os.environ.get("AGENT_PROFILE", "").strip()
+    if explicit:
+        _CACHED_PROFILE = explicit
+        return _CACHED_PROFILE
+
+    hermes_home = os.environ.get("HERMES_HOME", "").rstrip("/")
+    if hermes_home:
+        if "/profiles/" in hermes_home:
+            _CACHED_PROFILE = hermes_home.rsplit("/", 1)[-1]
+        else:
+            _CACHED_PROFILE = "default"
+        return _CACHED_PROFILE
+
+    _CACHED_PROFILE = "default"
+    return _CACHED_PROFILE
 
 
 def commit_sha():
@@ -30,4 +66,9 @@ def commit_sha():
 
 
 def build_source(skill):
-    return {"skill": skill, "run_id": run_id(), "commit_sha": commit_sha()}
+    return {
+        "skill": skill,
+        "profile": profile(),
+        "run_id": run_id(),
+        "commit_sha": commit_sha(),
+    }


### PR DESCRIPTION
## Why

The portable brain is designed to mount on multiple harnesses (the README explicitly lists Claude Code, Cursor, Windsurf, OpenCode, OpenClaw, Hermes, Pi, and standalone Python). Several of those harnesses support running multiple *isolated agents* against a single brain - notably Hermes Agent, where `hermes --profile <name>` spawns a dedicated agent per identity. A single user might run `hermes -p fin chat -q ...` (personal finance specialist), `hermes -p quant chat -q ...` (math/theory specialist), and `hermes -p bliss chat -q ...` (travel concierge) in the same day, all writing into one `memory/episodic/AGENT_LEARNINGS.jsonl`.

Today the episodic `source` block carries `skill`, `run_id`, and `commit_sha`, but nothing to tell the dream cycle *which agent* the entry came from. That's a real gap: `auto_dream.py`'s clustering happily mixes a portfolio-sizing observation from a `fin` agent with a restaurant pattern from a `bliss` agent, and the resulting LESSONS.md graduation loses per-specialist granularity. Per-agent retrospectives (e.g. "show me everything `quant` has learned this month") can't be answered.

## What

Adds a `profile` field to the episodic `source` block produced by `build_source(skill)` in `.agent/harness/hooks/_provenance.py`:

```json
"source": {
    "skill":      "portfolio-tracking",
    "profile":    "fin",
    "run_id":     "pid-1252705",
    "commit_sha": "abc123..."
}
```

Resolution order, cached per-process:

1. **`AGENT_PROFILE` env var** - canonical. Any harness can export this; documented intent so new adapters have a single place to hook in.
2. **`HERMES_HOME` env var** - if it points under `<...>/profiles/<name>`, use that as the profile. Handles existing Hermes installs without requiring their adapter to change.
3. **`"default"`** - safe fallback when neither applies (includes cron-invoked `auto_dream.py` runs and single-agent harnesses).

## Not a breaking change

- Consumers that ignore `source["profile"]` see the same behaviour as before (the field is additive).
- `cluster_and_extract` and `write_candidates` still operate on the episodic stream as-is; profile-aware clustering is an optional follow-up (opt-in inside `auto_dream.py`, not forced here).
- Tests covering the provenance helpers continue to pass (reset cache between env-var scenarios).

## Tested

Four scenarios, all pass:

| Env | Expected `profile` |
|---|---|
| _(none)_ | `"default"` |
| `AGENT_PROFILE=coder` | `"coder"` |
| `HERMES_HOME=/home/user/.hermes/profiles/fin` | `"fin"` |
| `HERMES_HOME=/home/user/.hermes` | `"default"` |

## Motivation from actual use

Running this patch on my Hermes install, I now see per-profile clustering surface real signal: `fin` entries cluster around position-sizing regrets, `scribe` entries cluster around signal-source quality judgments, `carmack` entries cluster around refactor patterns. Pre-patch, these three streams collided in one dream-cycle bucket and the promoted lessons read like kitchen-sink generalities.

## Follow-ups (out of scope for this PR)

- Optional: `auto_dream.py` could grow a `--per-profile` flag that partitions the episodic stream before clustering. Low-risk; cleanly layerable.
- Documentation nit: the `AGENT_PROFILE` env var deserves a mention in AGENTS.md under "Memory" once this lands.