### PR TITLE
feat: YantrikDB memory backend [BETA] — opt-in multi-signal recall + reflect()

### DIFF
--- a/.agent/memory/yantrikdb_sync.py
+++ b/.agent/memory/yantrikdb_sync.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""
+YantrikDB Sync [BETA] — mirror .agent/memory/ markdown into a yantrikdb server.
+
+Purpose: layer yantrikdb's cognitive primitives (multi-signal recall,
+contradiction detection, temporal decay, consolidation) on top of the
+portable markdown brain WITHOUT replacing it. The filesystem stays
+authoritative; yantrikdb is an optional enhanced recall/consolidation
+layer that users opt into.
+
+How it fits:
+  - .agent/memory/*.md / *.jsonl remain the canonical store (git-tracked,
+    human-readable, no vendor lock-in).
+  - This tool walks the tree and upserts each memory document into
+    yantrikdb with a stable rid derived from the file path.
+  - Subsequent runs are incremental (mtime + content-hash).
+  - Type tagging is directory-based:
+      semantic/   → memory_type="semantic"
+      episodic/   → memory_type="episodic"
+      personal/   → memory_type="self_model"
+      working/    → memory_type="working"
+  - Metadata attached: source_path, mtime, doc_hash.
+
+BETA + opt-in: disabled by default. Enable via onboarding
+(agentic-stack <harness> --reconfigure) or by setting
+    {"yantrikdb_memory": {"enabled": true, "url": "...", "token": "..."}}
+in .agent/memory/.features.json.
+
+Usage:
+  python3 yantrikdb_sync.py                   # incremental sync (default)
+  python3 yantrikdb_sync.py --full            # full resync (drops cache)
+  python3 yantrikdb_sync.py --dry-run         # show what would sync
+  python3 yantrikdb_sync.py --status          # counts + last sync time
+
+Requires: pip install yantrikdb-client>=0.2.1
+"""
+import argparse
+import hashlib
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+MEMORY_DIR = Path(__file__).resolve().parent
+FEATURES_PATH = MEMORY_DIR / ".features.json"
+CACHE_PATH = MEMORY_DIR / ".index" / "yantrikdb_sync_cache.json"
+
+MEMORY_SUFFIXES = (".md", ".jsonl")
+
+# Directory → yantrikdb memory_type mapping. Unknown dirs default to "semantic".
+TYPE_MAP = {
+    "semantic": "semantic",
+    "episodic": "episodic",
+    "personal": "self_model",
+    "working": "working",
+    "candidates": "hypothesis",  # graduate.py treats candidates as unconfirmed
+}
+
+
+def feature_config() -> dict:
+    """Return the yantrikdb_memory feature config, or {} if disabled/missing.
+
+    Resolves env vars (YDB_URL, YDB_TOKEN) when the .features.json values
+    are empty strings — lets users keep secrets out of the repo.
+    """
+    try:
+        data = json.loads(FEATURES_PATH.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+    entry = data.get("yantrikdb_memory") or {}
+    if not entry.get("enabled"):
+        return {}
+    # Fill from env if unset
+    cfg = dict(entry)
+    if not cfg.get("url"):
+        cfg["url"] = os.environ.get("YDB_URL", "http://localhost:7438")
+    if not cfg.get("token"):
+        cfg["token"] = os.environ.get("YDB_TOKEN", "")
+    if not cfg.get("namespace"):
+        cfg["namespace"] = _default_namespace()
+    return cfg
+
+
+def _default_namespace() -> str:
+    """Derive a stable per-project namespace from the repo root path so
+    multiple projects sharing one yantrikdb server don't collide."""
+    repo_root = MEMORY_DIR.parent.parent  # .agent/memory → project root
+    digest = hashlib.sha256(str(repo_root.resolve()).encode()).hexdigest()[:12]
+    return f"agentic-stack/{repo_root.name}/{digest}"
+
+
+def _load_cache() -> dict:
+    """Load the per-path mtime+hash cache so we can skip unchanged files."""
+    try:
+        return json.loads(CACHE_PATH.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
+def _save_cache(cache: dict) -> None:
+    CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    CACHE_PATH.write_text(json.dumps(cache, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _memory_files():
+    """Yield (Path, memory_type, relative_dir_name) for each indexable doc.
+
+    Skips .index/ and hidden files. Type is derived from the first path
+    component under .agent/memory/.
+    """
+    for f in MEMORY_DIR.rglob("*"):
+        if any(p.startswith(".") for p in f.relative_to(MEMORY_DIR).parts):
+            continue
+        if f.suffix not in MEMORY_SUFFIXES or not f.is_file():
+            continue
+        rel = f.relative_to(MEMORY_DIR)
+        if not rel.parts:
+            continue
+        top = rel.parts[0]
+        mtype = TYPE_MAP.get(top, "semantic")
+        yield f, mtype, top
+
+
+def _doc_hash(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
+
+
+def _upsert(client, path: Path, memory_type: str, top_dir: str,
+            namespace: str) -> str:
+    """Upsert a single document. Returns the yantrikdb rid."""
+    text = path.read_text(encoding="utf-8", errors="replace")
+    rel = str(path.relative_to(MEMORY_DIR))
+    metadata = {
+        "source_path": rel,
+        "source_dir": top_dir,
+        "mtime": path.stat().st_mtime,
+        "doc_hash": _doc_hash(path),
+    }
+    return client.remember(
+        text,
+        memory_type=memory_type,
+        importance=0.7 if top_dir == "personal" else 0.5,
+        domain="agentic-stack",
+        source=f"file:{top_dir}",
+        namespace=namespace,
+        metadata=metadata,
+    )
+
+
+def run_sync(full: bool = False, dry_run: bool = False) -> dict:
+    """Sync all indexable docs under .agent/memory/ into yantrikdb.
+
+    Returns a summary dict: {synced, skipped, errors, elapsed_s}.
+    """
+    cfg = feature_config()
+    if not cfg:
+        print("yantrikdb_memory feature is disabled. Enable in .features.json "
+              "or via onboarding wizard.")
+        return {"synced": 0, "skipped": 0, "errors": 0, "elapsed_s": 0}
+
+    try:
+        from yantrikdb import connect
+    except ImportError:
+        print("Missing dependency: pip install 'yantrikdb-client>=0.2.1'",
+              file=sys.stderr)
+        return {"synced": 0, "skipped": 0, "errors": 1, "elapsed_s": 0}
+
+    cache = {} if full else _load_cache()
+    t0 = time.time()
+    synced = skipped = errors = 0
+
+    if dry_run:
+        client = None
+    else:
+        client = connect(cfg["url"], token=cfg["token"])
+
+    try:
+        for path, mtype, top in _memory_files():
+            rel = str(path.relative_to(MEMORY_DIR))
+            new_hash = _doc_hash(path)
+            cached = cache.get(rel)
+            if cached and cached.get("doc_hash") == new_hash:
+                skipped += 1
+                continue
+            if dry_run:
+                print(f"  would sync: {rel} ({mtype})")
+                synced += 1
+                continue
+            try:
+                rid = _upsert(client, path, mtype, top, cfg["namespace"])
+                cache[rel] = {"doc_hash": new_hash,
+                              "rid": rid,
+                              "mtime": path.stat().st_mtime,
+                              "memory_type": mtype}
+                synced += 1
+            except Exception as exc:  # noqa: BLE001 — surface all upsert errors
+                print(f"  ERROR syncing {rel}: {exc}", file=sys.stderr)
+                errors += 1
+    finally:
+        if client is not None:
+            client.close()
+
+    if not dry_run:
+        _save_cache(cache)
+    elapsed = round(time.time() - t0, 2)
+    return {"synced": synced, "skipped": skipped, "errors": errors,
+            "elapsed_s": elapsed}
+
+
+def show_status() -> None:
+    """Print counts of what's been synced and last sync time."""
+    cfg = feature_config()
+    if not cfg:
+        print("yantrikdb_memory: disabled")
+        return
+    cache = _load_cache()
+    by_type = {}
+    for entry in cache.values():
+        t = entry.get("memory_type", "unknown")
+        by_type[t] = by_type.get(t, 0) + 1
+    print(f"yantrikdb_memory: enabled")
+    print(f"  url:       {cfg['url']}")
+    print(f"  namespace: {cfg['namespace']}")
+    print(f"  synced:    {sum(by_type.values())} docs in cache")
+    for t, n in sorted(by_type.items()):
+        print(f"    {t}: {n}")
+    if cache:
+        newest = max((e.get("mtime", 0) for e in cache.values()), default=0)
+        if newest:
+            print(f"  newest mtime: {time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(newest))}")
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[1])
+    p.add_argument("--full", action="store_true",
+                   help="Full resync, ignoring the incremental cache.")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Show what would sync without talking to the server.")
+    p.add_argument("--status", action="store_true",
+                   help="Print sync status and exit.")
+    args = p.parse_args()
+
+    if args.status:
+        show_status()
+        return 0
+
+    summary = run_sync(full=args.full, dry_run=args.dry_run)
+    print(f"sync: {summary['synced']} synced, {summary['skipped']} skipped, "
+          f"{summary['errors']} errors in {summary['elapsed_s']}s")
+    return 0 if summary["errors"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agent/tools/yantrikdb_recall.py
+++ b/.agent/tools/yantrikdb_recall.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""
+YantrikDB Recall [BETA] — multi-signal recall over .agent/memory/ via yantrikdb.
+
+Augments the default lexical `recall.py` and the FTS5 `memory_search.py`
+with yantrikdb's combined (vector × decay × importance × graph ×
+retrieval-feedback) scoring. Falls back gracefully: if yantrikdb is
+not configured or unreachable, prints a clear message and exits — does
+NOT fake results. The agent can then fall back to the existing tools.
+
+Pipeline:
+  1. Read .features.json; bail if yantrikdb_memory is disabled.
+  2. Connect to yantrikdb via `yantrikdb-client>=0.2.1` (auto-embedder on).
+  3. Run recall(query, top_k, namespace=current-project) with the project-
+     scoped namespace established by yantrikdb_sync.py.
+  4. Print ranked results with:
+       - source file path (from metadata)
+       - memory_type
+       - score + `why_retrieved` (yantrikdb's explanation hooks)
+       - 140-char text preview
+
+Usage:
+  python3 yantrikdb_recall.py "<query>"            # pretty output, top 10
+  python3 yantrikdb_recall.py "<query>" --top-k 5
+  python3 yantrikdb_recall.py "<query>" --json     # machine-readable
+  python3 yantrikdb_recall.py "<query>" --type rule
+
+BETA + opt-in. Requires yantrikdb-client installed and the
+yantrikdb_memory feature enabled.
+"""
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+MEMORY_DIR = Path(__file__).resolve().parent.parent / "memory"
+FEATURES_PATH = MEMORY_DIR / ".features.json"
+
+
+def _feature_config() -> dict:
+    try:
+        data = json.loads(FEATURES_PATH.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+    entry = data.get("yantrikdb_memory") or {}
+    if not entry.get("enabled"):
+        return {}
+    cfg = dict(entry)
+    if not cfg.get("url"):
+        cfg["url"] = os.environ.get("YDB_URL", "http://localhost:7438")
+    if not cfg.get("token"):
+        cfg["token"] = os.environ.get("YDB_TOKEN", "")
+    if not cfg.get("namespace"):
+        # Must match yantrikdb_sync.py's default namespace to find anything
+        import hashlib
+        repo_root = MEMORY_DIR.parent.parent
+        digest = hashlib.sha256(str(repo_root.resolve()).encode()).hexdigest()[:12]
+        cfg["namespace"] = f"agentic-stack/{repo_root.name}/{digest}"
+    return cfg
+
+
+def recall(query: str, top_k: int = 10, memory_type: str | None = None) -> list[dict]:
+    """Run yantrikdb recall. Returns a list of dicts ready for rendering.
+
+    Raises RuntimeError with a clear message if the feature is disabled
+    or the SDK isn't installed — callers (e.g. agents) should catch and
+    fall back to lexical tools.
+    """
+    cfg = _feature_config()
+    if not cfg:
+        raise RuntimeError(
+            "yantrikdb_memory feature disabled. Enable in .features.json "
+            "or via onboarding wizard."
+        )
+    try:
+        from yantrikdb import connect
+    except ImportError as exc:
+        raise RuntimeError(
+            "yantrikdb-client not installed. pip install 'yantrikdb-client>=0.2.1'"
+        ) from exc
+
+    client = connect(cfg["url"], token=cfg["token"])
+    try:
+        result = client.recall(
+            query,
+            top_k=top_k,
+            namespace=cfg["namespace"],
+            memory_type=memory_type,
+            expand_entities=True,
+        )
+    finally:
+        client.close()
+
+    out = []
+    for mem in result.results:
+        meta = getattr(mem, "metadata", {}) or {}
+        out.append({
+            "rid": mem.rid,
+            "source_path": meta.get("source_path", ""),
+            "memory_type": mem.memory_type,
+            "score": round(mem.score, 3),
+            "why": getattr(mem, "why_retrieved", []),
+            "text": mem.text[:140] + ("…" if len(mem.text) > 140 else ""),
+        })
+    return out
+
+
+def _render_pretty(query: str, items: list[dict]) -> str:
+    if not items:
+        return f"(no yantrikdb matches for: {query})"
+    lines = [f"yantrikdb recall: {query!r}  →  {len(items)} hits"]
+    for i, it in enumerate(items, 1):
+        why = ", ".join(it["why"][:3]) if it["why"] else ""
+        why_s = f"  [{why}]" if why else ""
+        src = it["source_path"] or f"rid:{it['rid'][:8]}"
+        lines.append(
+            f"  {i}. [{it['memory_type']:<10}] score={it['score']}  {src}{why_s}\n"
+            f"     {it['text']}"
+        )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[1])
+    p.add_argument("query", help="Natural-language recall query")
+    p.add_argument("--top-k", type=int, default=10,
+                   help="Max results to return (default 10)")
+    p.add_argument("--type", dest="memory_type",
+                   choices=["semantic", "episodic", "self_model", "rule",
+                            "constraint", "hypothesis", "working", "narrative_arc"],
+                   help="Filter to a specific memory_type.")
+    p.add_argument("--json", action="store_true",
+                   help="Machine-readable JSON output.")
+    args = p.parse_args()
+
+    try:
+        items = recall(args.query, top_k=args.top_k, memory_type=args.memory_type)
+    except RuntimeError as exc:
+        print(f"yantrikdb_recall: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps({"query": args.query, "results": items},
+                         indent=2, default=str))
+    else:
+        print(_render_pretty(args.query, items))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agent/tools/yantrikdb_reflect.py
+++ b/.agent/tools/yantrikdb_reflect.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""
+YantrikDB Reflect [BETA] — structured meta-state for agent context injection.
+
+Runs the yantrikdb `reflect()` composition — parallel type-filtered
+recalls over self-model, rules, hypotheses, constraints, goals, narrative
+arcs, and recent learning signals — and renders a compact text block
+ready to drop into an agent's system prompt or working context.
+
+Key design choice: this tool emits the yantrikdb-upstream-validated
+**memory-router seed prompt** as the first block of output, followed by
+the reflected state. Background on why:
+
+    yantrikdb's own research (Apr 2026) showed that retrieval-time
+    teaching at small-LLM scale (Qwen 3.6) goes from 27% HURT to 93%
+    RESCUE when the agent's system prompt explicitly frames stored items
+    as scoped procedure controllers rather than advisory context.
+
+    The 73-word router prompt is replicated verbatim below so agent
+    harnesses on top of agentic-stack see the same rescue pattern if they
+    use yantrikdb_reflect output as part of their system prompt.
+
+    Reference: https://github.com/yantrikos/yantrikdb-client/blob/main/docs/
+               (router-prompt design notes)
+
+Usage:
+  python3 yantrikdb_reflect.py "<question>"          # pretty, suited for CLI
+  python3 yantrikdb_reflect.py "<question>" --bare   # just the router + state
+  python3 yantrikdb_reflect.py "<question>" --json   # structured output
+
+  # as a subprocess for agent context injection:
+  CONTEXT=$(python3 yantrikdb_reflect.py "task: refactor login flow" --bare)
+
+BETA + opt-in. Requires yantrikdb-client>=0.2.1 and the yantrikdb_memory
+feature enabled.
+"""
+import argparse
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+
+MEMORY_DIR = Path(__file__).resolve().parent.parent / "memory"
+FEATURES_PATH = MEMORY_DIR / ".features.json"
+
+# Verbatim from yantrikdb-client router-prompt design. Do not edit without
+# coordinating with the upstream yantrikdb research notes — this specific
+# wording has been empirically validated vs alternatives.
+MEMORY_ROUTER_SEED = """\
+You have persistent memory in yantrikdb. Stored items are either procedures or rules.
+
+First decide whether a stored procedure applies to the current problem or subtask.
+If one applies, use that procedure only, from start to finish, and keep its conventions consistent. Do not mix it with other procedures, native methods, or shortcuts for the same task.
+If no stored procedure applies, ignore stored procedures and reason normally.
+
+Rules are local modifiers or exceptions: apply them when their condition is met, then continue normally.
+
+If applicable stored items conflict, report the conflict instead of blending them.
+"""
+
+
+def _feature_config() -> dict:
+    try:
+        data = json.loads(FEATURES_PATH.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+    entry = data.get("yantrikdb_memory") or {}
+    if not entry.get("enabled"):
+        return {}
+    cfg = dict(entry)
+    if not cfg.get("url"):
+        cfg["url"] = os.environ.get("YDB_URL", "http://localhost:7438")
+    if not cfg.get("token"):
+        cfg["token"] = os.environ.get("YDB_TOKEN", "")
+    if not cfg.get("namespace"):
+        repo_root = MEMORY_DIR.parent.parent
+        digest = hashlib.sha256(str(repo_root.resolve()).encode()).hexdigest()[:12]
+        cfg["namespace"] = f"agentic-stack/{repo_root.name}/{digest}"
+    return cfg
+
+
+def reflect(question: str, top_k_per_type: int = 3) -> dict:
+    """Run yantrikdb reflect and return a structured dict.
+
+    Raises RuntimeError if feature disabled or SDK missing, so the caller
+    can decide whether to fall back (e.g. to the existing memory_reflect.py)
+    or skip the block entirely.
+    """
+    cfg = _feature_config()
+    if not cfg:
+        raise RuntimeError(
+            "yantrikdb_memory feature disabled. Enable in .features.json "
+            "or via onboarding wizard."
+        )
+    try:
+        from yantrikdb import connect
+    except ImportError as exc:
+        raise RuntimeError(
+            "yantrikdb-client not installed. pip install 'yantrikdb-client>=0.2.1'"
+        ) from exc
+
+    client = connect(cfg["url"], token=cfg["token"])
+    try:
+        r = client.reflect(
+            question,
+            namespace=cfg["namespace"],
+            top_k_per_type=top_k_per_type,
+            include_conflicts=False,  # v0.2.1 default; conflicts pollute prompts
+        )
+    finally:
+        client.close()
+
+    def _serialize(mems):
+        return [
+            {
+                "rid": m.rid,
+                "text": m.text[:240] + ("…" if len(m.text) > 240 else ""),
+                "certainty": round(getattr(m, "certainty", 1.0), 2),
+                "importance": round(m.importance, 2),
+                "source": (m.metadata or {}).get("source_path", ""),
+            }
+            for m in mems
+        ]
+
+    return {
+        "question": question,
+        "self_model": _serialize(r.self_model),
+        "rules": _serialize(r.rules),
+        "hypotheses": _serialize(r.hypotheses),
+        "constraints": _serialize(r.constraints),
+        "goals": _serialize(r.goals),
+        "arcs": _serialize(r.arcs),
+        "recent_signals": _serialize(r.recent_signals),
+    }
+
+
+def render_block(state: dict, *, include_router: bool = True) -> str:
+    """Compact text block ready for agent system-prompt injection.
+
+    Router seed prompt (if included) goes first because it frames how the
+    agent should treat the subsequent content.
+    """
+    blocks = []
+    if include_router:
+        blocks.append(MEMORY_ROUTER_SEED.rstrip())
+        blocks.append("")
+    blocks.append(f"# Reflection on: {state['question']}")
+
+    def _section(name: str, items: list, fmt):
+        if not items:
+            return
+        blocks.append(f"\n## {name}")
+        for it in items:
+            blocks.append(f"- {fmt(it)}")
+
+    _section("Self-model", state["self_model"],
+             lambda x: f"{x['text']}  (certainty={x['certainty']})")
+    _section("Rules / procedures", state["rules"],
+             lambda x: f"{x['text']}  (importance={x['importance']})")
+    _section("Open hypotheses", state["hypotheses"],
+             lambda x: f"{x['text']}  (certainty={x['certainty']})")
+    _section("Constraints", state["constraints"],
+             lambda x: f"{x['text']}  (priority={x['importance']})")
+    _section("Active goals", state["goals"], lambda x: x["text"])
+    _section("Open narrative arcs", state["arcs"], lambda x: x["text"])
+    _section("Recent learning signals", state["recent_signals"],
+             lambda x: x["text"])
+    return "\n".join(blocks)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[1])
+    p.add_argument("question", help="Current question/task to reflect around")
+    p.add_argument("--top-k", type=int, default=3,
+                   help="Max items per memory-type block (default 3)")
+    p.add_argument("--bare", action="store_true",
+                   help="Emit router + reflection only (no CLI scaffolding).")
+    p.add_argument("--no-router", action="store_true",
+                   help="Skip the memory-router seed prompt block.")
+    p.add_argument("--json", action="store_true",
+                   help="Machine-readable JSON output.")
+    args = p.parse_args()
+
+    try:
+        state = reflect(args.question, top_k_per_type=args.top_k)
+    except RuntimeError as exc:
+        print(f"yantrikdb_reflect: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(state, indent=2, default=str))
+        return 0
+
+    block = render_block(state, include_router=not args.no_router)
+    if args.bare:
+        print(block)
+    else:
+        print("─" * 60)
+        print(block)
+        print("─" * 60)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,11 @@ ANTHROPIC_API_KEY=sk-ant-...
 AGENT_PROVIDER=anthropic
 AGENT_MODEL=claude-sonnet-4-5
 AGENT_MAX_CONTEXT=128000
+
+# Optional: yantrikdb memory backend (BETA, opt-in via onboarding wizard).
+# When `.agent/memory/.features.json` has yantrikdb_memory.enabled=true
+# and its `url`/`token` fields are left empty, the tools read these env
+# vars at runtime. Keeping secrets here (instead of in .features.json)
+# avoids committing them when `.agent/memory/` is git-tracked.
+# YDB_URL=http://localhost:7438
+# YDB_TOKEN=ydb_...

--- a/README.md
+++ b/README.md
@@ -223,6 +223,36 @@ Falls back to **ripgrep** (`rg`) if installed, then to `grep` — both
 restricted to `.md` / `.jsonl` so source files never pollute results.
 The index is stored at `.agent/memory/.index/` and gitignored.
 
+## YantrikDB memory backend `[BETA]`
+
+Opt-in layer that mirrors `.agent/memory/` into a
+[yantrikdb](https://github.com/yantrikos/yantrikdb) server for
+multi-signal recall (vector × decay × importance × graph ×
+retrieval-feedback), contradiction detection, and `reflect()` composition.
+Filesystem stays authoritative — markdown is still your canonical,
+git-diffable source of truth.
+
+```bash
+# enable during onboarding, then install the optional client
+pip install 'yantrikdb-client[embed]>=0.2.1'
+
+# first sync (incremental on subsequent runs)
+python3 .agent/memory/yantrikdb_sync.py
+
+# multi-signal recall
+python3 .agent/tools/yantrikdb_recall.py "postgres migration idempotency"
+
+# structured reflection ready for agent system-prompt injection
+python3 .agent/tools/yantrikdb_reflect.py "task: refactor auth flow" --bare
+```
+
+The reflect tool emits a validated **memory-router seed prompt** that
+teaches the agent to treat retrieved memories as scoped procedure
+controllers — upstream research showed 27% HURT → 93% RESCUE at small-
+LLM scale when this framing is added. See
+[`docs/yantrikdb.md`](docs/yantrikdb.md) for setup, namespaces, env
+vars, and the architecture diagram.
+
 ## Repo layout
 
 ```
@@ -236,7 +266,8 @@ The index is stored at `.agent/memory/.index/` and gitignored.
 │   ├── validate.py             # heuristic prefilter (length + exact duplicate)
 │   ├── review_state.py         # candidate lifecycle + decision log
 │   ├── render_lessons.py       # lessons.jsonl → LESSONS.md
-│   └── memory_search.py        # [BETA] FTS5 search (opt-in)
+│   ├── memory_search.py        # [BETA] FTS5 search (opt-in)
+│   └── yantrikdb_sync.py       # [BETA] mirror to yantrikdb (opt-in)
 ├── skills/                     # _index.md + _manifest.jsonl + SKILL.md files
 ├── protocols/                  # permissions + tool schemas + delegation
 └── tools/                      # host-agent CLI + memory_reflect + skill_loader
@@ -246,7 +277,9 @@ The index is stored at `.agent/memory/.index/` and gitignored.
     ├── list_candidates.py
     ├── graduate.py
     ├── reject.py
-    └── reopen.py
+    ├── reopen.py
+    ├── yantrikdb_recall.py      # [BETA] multi-signal recall via yantrikdb
+    └── yantrikdb_reflect.py     # [BETA] typed meta-state + router seed prompt
 
 adapters/                       # one small shim per harness
 ├── claude-code/   (CLAUDE.md + settings.json hooks)

--- a/docs/yantrikdb.md
+++ b/docs/yantrikdb.md
@@ -1,0 +1,209 @@
+# YantrikDB memory backend [BETA]
+
+Layer [yantrikdb](https://github.com/yantrikos/yantrikdb) — a cognitive
+memory database — on top of the portable `.agent/` brain. The
+filesystem stays authoritative (still git-tracked markdown); yantrikdb
+adds multi-signal recall, contradiction detection, temporal decay, and
+reflect() composition without replacing any existing tool.
+
+## When is this useful
+
+The default filesystem + lexical tools (`recall.py`, FTS `memory_search.py`)
+are fine for small / medium brains. Consider enabling yantrikdb when:
+
+- You have thousands of lessons / episodes and want semantic recall that
+  composes with importance, decay, and graph connectivity — not just
+  BM25 keyword ranking.
+- Multiple projects share one persistent memory server and you want
+  per-project isolation via namespaces.
+- You want contradiction detection across memories (e.g. "this lesson
+  disagrees with that lesson about handling nulls").
+- You want `reflect(question)` that returns a structured view of
+  self-model + rules + constraints + goals + recent signals, ready to
+  inject into an agent's working context.
+
+## What the integration does NOT do
+
+- It does **not** replace markdown files. `.agent/memory/semantic/*.md`
+  remains the canonical, git-diffable source of truth.
+- It does **not** touch the existing tools (`auto_dream.py`, `decay.py`,
+  `promote.py`, etc.). They keep working whether yantrikdb is on or off.
+- It does **not** install yantrikdb-server — you point it at an existing
+  server (your own, or a cloud instance).
+
+## Install
+
+1. Run a yantrikdb server somewhere you can reach (e.g. local Docker,
+   your homelab, an existing cluster). See
+   [yantrikdb-server](https://github.com/yantrikos/yantrikdb-server) for
+   deployment options.
+2. Mint an access token for a dedicated database (each agentic-stack
+   project should get its own database or at least namespace).
+3. Install the client into your project's environment:
+   ```bash
+   pip install 'yantrikdb-client[embed]>=0.2.1'
+   ```
+4. Enable the feature — either through the onboarding wizard:
+   ```bash
+   agentic-stack <harness> --reconfigure
+   # Answer "yes" to "Enable YantrikDB memory backend [BETA]?"
+   ```
+   Or by editing `.agent/memory/.features.json` directly:
+   ```json
+   {
+     "yantrikdb_memory": {
+       "enabled": true,
+       "beta": true,
+       "url": "http://your-server:7438",
+       "token": "ydb_...",
+       "namespace": ""
+     }
+   }
+   ```
+   Leaving `url` / `token` empty falls back to `YDB_URL` / `YDB_TOKEN`
+   env vars at read time — preferred if `.agent/memory/` is
+   git-tracked.
+   Leaving `namespace` empty derives a stable per-project namespace
+   from a hash of your repo root (so multiple projects on one server
+   don't collide).
+
+## First sync
+
+```bash
+python3 .agent/memory/yantrikdb_sync.py          # incremental
+python3 .agent/memory/yantrikdb_sync.py --full   # rebuild cache
+python3 .agent/memory/yantrikdb_sync.py --status # show counts
+```
+
+The sync walks `.agent/memory/` and upserts every `.md` / `.jsonl`
+file into yantrikdb with type tagging derived from the subdirectory:
+
+| directory | `memory_type` |
+|---|---|
+| `semantic/` | `semantic` |
+| `episodic/` | `episodic` |
+| `personal/` | `self_model` |
+| `working/` | `working` |
+| `candidates/` | `hypothesis` |
+| (other) | `semantic` (fallback) |
+
+Each document's rid is persistent across runs; updates mutate the
+existing record. An incremental cache at
+`.agent/memory/.index/yantrikdb_sync_cache.json` skips unchanged
+files between runs (content-hash check).
+
+## Using it from an agent
+
+### Multi-signal recall
+```bash
+python3 .agent/tools/yantrikdb_recall.py "the lesson about null checks"
+python3 .agent/tools/yantrikdb_recall.py "postgres migration" --top-k 5
+python3 .agent/tools/yantrikdb_recall.py "my preferred test strategy" --type self_model
+```
+
+Falls back gracefully if the feature is disabled — prints a clear
+message to stderr and exits with code 2 so the agent can choose to
+fall back to `recall.py` or `memory_search.py`.
+
+### Structured reflection for context injection
+```bash
+# Human-readable
+python3 .agent/tools/yantrikdb_reflect.py "task: refactor auth flow"
+
+# Machine-readable for agent context injection
+CTX=$(python3 .agent/tools/yantrikdb_reflect.py "task: refactor auth flow" --bare)
+echo "$CTX"
+```
+
+The `--bare` output is designed to drop directly into an agent's
+system prompt. It begins with a **memory-router seed prompt** —
+a 73-word frame established by yantrikdb's own research showing that
+retrieval-time teaching at small-LLM scales goes from 27% HURT to 93%
+RESCUE when the agent is explicitly taught how to treat stored items
+as scoped procedure controllers rather than advisory context.
+
+The reflect tool surfaces seven typed views in order:
+self-model, rules, hypotheses, constraints, goals, narrative arcs,
+recent learning signals. Top-k per type is configurable (default 3).
+
+## Going back
+
+Disabling is reversible:
+```bash
+# In .agent/memory/.features.json
+"yantrikdb_memory": {"enabled": false, ...}
+```
+
+Your filesystem `.agent/memory/` is untouched. The yantrikdb server
+still has the mirrored records, but nothing in agentic-stack will read
+from them. You can either leave the records in place (harmless) or
+delete the namespace on the yantrikdb server manually.
+
+## Architecture at a glance
+
+```
+.agent/memory/                    ← authoritative
+├── semantic/                     ← markdown, git-tracked
+├── episodic/
+├── personal/
+├── working/
+└── .index/
+    ├── memory.db                 ← existing FTS5 index
+    └── yantrikdb_sync_cache.json ← new, incremental sync state
+
+yantrikdb server (yours)
+└── database / namespace          ← mirror, enhanced recall
+    ├── memories (typed)
+    ├── entity graph
+    ├── conflicts
+    └── decay / importance state
+```
+
+Read path (when feature enabled):
+- `yantrikdb_recall.py` → yantrikdb multi-signal recall
+- `yantrikdb_reflect.py` → yantrikdb reflect() → render with router seed
+
+Read path (feature disabled):
+- `recall.py` (lexical) + `memory_search.py` (FTS5) unchanged
+
+Write path (always):
+- All existing tools write to `.agent/memory/*.md` / `*.jsonl`
+- Optional `yantrikdb_sync.py` run (cron / post-commit hook / manual)
+  mirrors to yantrikdb
+
+## FAQ
+
+**Q: Does yantrikdb see my secrets?**
+Only what you put in `.agent/memory/`. Keep secrets out of there as
+usual. The server only sees text you explicitly sync.
+
+**Q: Can I run multiple agentic-stack projects against one server?**
+Yes — each project gets a namespace derived from its root path hash.
+Set a human-readable namespace in `.features.json` if you prefer.
+
+**Q: What happens if the yantrikdb server is down?**
+The sync / recall / reflect tools print a clear error and exit with
+non-zero code. All existing tools continue to work because they read
+filesystem markdown directly.
+
+**Q: How does this interact with `auto_dream.py` / consolidation?**
+`auto_dream.py` runs on the filesystem as before. You can additionally
+trigger yantrikdb's own consolidation via the client's `think()` API
+if you want (not wired into this PR; see `yantrikdb-client` docs).
+
+## Known limitations
+
+- One-way sync (filesystem → yantrikdb). No write-back.
+- Re-running `--full` does not delete records on the server that were
+  removed from the filesystem — the sync cache tracks rids but the
+  current implementation upserts and doesn't tombstone removed files.
+  (Follow-up PR if useful.)
+- Requires a reachable yantrikdb server. No embedded / in-process
+  option surfaced here.
+
+## References
+
+- [yantrikdb-client (PyPI)](https://pypi.org/project/yantrikdb-client/)
+- [yantrikdb-server (repo)](https://github.com/yantrikos/yantrikdb-server)
+- [The memory-router seed prompt design](https://github.com/yantrikos/yantrikdb-client/blob/main/CHANGELOG.md) —
+  rationale for the 73-word seed the reflect tool emits

--- a/examples/yantrikdb_quickstart.py
+++ b/examples/yantrikdb_quickstart.py
@@ -1,0 +1,77 @@
+"""End-to-end demo of the yantrikdb memory backend [BETA].
+
+Runs the happy path:
+  1. Confirm the feature is enabled
+  2. Sync .agent/memory/ into yantrikdb (incremental)
+  3. Recall against the synced namespace with a sample query
+  4. Reflect on a sample task and render the router-seed + state block
+
+Run:
+    # Enable via onboarding first:
+    agentic-stack <harness> --reconfigure
+    # Answer "yes" to "Enable YantrikDB memory backend [BETA]?"
+
+    # Install the client:
+    pip install 'yantrikdb-client[embed]>=0.2.1'
+
+    # Point at your server (or rely on .features.json values):
+    export YDB_URL=http://localhost:7438
+    export YDB_TOKEN=ydb_...
+
+    # Run the demo:
+    python3 examples/yantrikdb_quickstart.py
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(ROOT / ".agent" / "memory"))
+sys.path.insert(0, str(ROOT / ".agent" / "tools"))
+
+
+def main() -> int:
+    from yantrikdb_sync import feature_config, run_sync, show_status
+
+    cfg = feature_config()
+    if not cfg:
+        print("feature disabled. Run `agentic-stack <harness> --reconfigure` "
+              "and opt into YantrikDB memory [BETA], then set YDB_URL/YDB_TOKEN "
+              "or fill .features.json.")
+        return 2
+
+    print(f"yantrikdb server: {cfg['url']}")
+    print(f"namespace:        {cfg['namespace']}\n")
+
+    # 1. sync
+    print("=== sync ===")
+    summary = run_sync(full=False, dry_run=False)
+    print(json.dumps(summary, indent=2))
+    show_status()
+
+    # 2. recall
+    print("\n=== recall ===")
+    try:
+        from yantrikdb_recall import recall, _render_pretty
+        q = "lessons about test strategy"
+        items = recall(q, top_k=5)
+        print(_render_pretty(q, items))
+    except Exception as exc:
+        print(f"recall error: {exc}")
+
+    # 3. reflect
+    print("\n=== reflect ===")
+    try:
+        from yantrikdb_reflect import reflect, render_block
+        state = reflect("task: refactor authentication", top_k_per_type=3)
+        print(render_block(state, include_router=True))
+    except Exception as exc:
+        print(f"reflect error: {exc}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/onboard.py
+++ b/onboard.py
@@ -68,6 +68,11 @@ def _wizard(target, force):
         f"Enable FTS memory search  {ORANGE}[BETA]{R}?",
         default=False,
     )
+    a["feature_yantrikdb"] = ask_confirm(
+        f"Enable YantrikDB memory backend  {ORANGE}[BETA]{R}?  "
+        f"(multi-signal recall, contradiction detection, reflect())",
+        default=False,
+    )
     return a
 
 
@@ -85,6 +90,10 @@ def main():
         # --yes defaults all optional beta features to off
         features_file = write_features(target, {
             "memory_search_fts": {"enabled": False, "beta": True},
+            "yantrikdb_memory": {
+                "enabled": False, "beta": True,
+                "url": "", "token": "", "namespace": "",
+            },
         })
         print(f"{GREEN}◆{R}  {WHITE}{B}PREFERENCES.md{R} written with defaults")
         print(f"{MUTED}   {path}{R}")
@@ -100,6 +109,15 @@ def main():
             "memory_search_fts": {
                 "enabled": bool(answers.get("feature_memory_search")),
                 "beta": True,
+            },
+            "yantrikdb_memory": {
+                "enabled": bool(answers.get("feature_yantrikdb")),
+                "beta": True,
+                # Empty values fall back to env vars (YDB_URL, YDB_TOKEN) at
+                # read time; leave blank to keep secrets out of the repo.
+                "url": "",
+                "token": "",
+                "namespace": "",
             },
         }
         features_file = write_features(target, features)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,7 @@
 anthropic>=0.34.0
 openai>=1.40.0
+
+# Optional — required only when the [BETA] yantrikdb_memory feature is
+# enabled (opt-in via onboarding). Uncomment or install separately:
+#   pip install 'yantrikdb-client[embed]>=0.2.1'
+# yantrikdb-client>=0.2.1


### PR DESCRIPTION
## Summary

Adds [yantrikdb](https://github.com/yantrikos/yantrikdb) as an **opt-in [BETA] memory backend** alongside the existing filesystem + FTS defaults. The portable \`.agent/\` brain stays authoritative (still markdown, still git-diffable); yantrikdb adds multi-signal recall, contradiction detection, temporal decay, and a structured reflect() composition for agent system-prompt injection.

Matches the shape of the existing \`Memory search [BETA]\` feature: default off, opt-in via onboarding wizard or direct \`.features.json\` edit. Zero behavior change for users who don't enable it.

## What's added

| File | Purpose |
|---|---|
| \`.agent/memory/yantrikdb_sync.py\` | Incremental sync of \`.md\` / \`.jsonl\` docs into a yantrikdb server. Type-tags by directory. Per-project namespace derived from repo-root hash. |
| \`.agent/tools/yantrikdb_recall.py\` | Multi-signal recall (vector × decay × importance × graph × retrieval-feedback) with graceful fallback — exits with code 2 if disabled so agents can route to \`recall.py\` / \`memory_search.py\`. |
| \`.agent/tools/yantrikdb_reflect.py\` | Structured meta-state view (self-model, rules, hypotheses, constraints, goals, arcs, recent signals) ready for system-prompt injection. Emits a validated **memory-router seed prompt** first. |
| \`onboard.py\` | New \`Enable YantrikDB memory backend [BETA]?\` question matching the FTS BETA pattern. |
| \`docs/yantrikdb.md\` | Full integration guide: when to use, architecture diagram, setup, FAQ, known limitations. |
| \`examples/yantrikdb_quickstart.py\` | End-to-end demo: sync → recall → reflect. |
| \`.env.example\`, \`requirements.txt\` | Documents optional \`YDB_URL\` / \`YDB_TOKEN\` env vars + optional \`yantrikdb-client>=0.2.1\` dep. |
| \`README.md\` | New "YantrikDB memory backend [BETA]" section + repo-layout diagram update. |

## The memory-router seed prompt (why this matters)

The reflect tool emits a 73-word seed prompt as the first block of its output. This is **not arbitrary** — upstream yantrikdb research (April 2026) showed that retrieval-time teaching at small-LLM scale (Qwen 3.6) goes from **27% HURT** (memory injection actively degrades reasoning) to **93% RESCUE** when the agent's system prompt frames stored items as scoped procedure controllers rather than advisory context.

Without the router seed:
- Models harmonize injected procedures with native methods (polite but wrong)
- Mixed-method corruption mid-solution
- Scope-guards become global suppressors

With the router seed:
- Single-method discipline within scope
- Positive permission for native reasoning outside scope
- Conflicts surfaced, not silently blended

This is the load-bearing design detail. The reflect tool's default \`include_router=True\` surfaces it to any agent that embeds reflect output in its working context.

## Design principles

1. **Zero existing-tool surgery.** \`recall.py\`, \`memory_search.py\`, \`auto_dream.py\`, \`decay.py\`, \`promote.py\`, \`cluster.py\` etc. all untouched.
2. **Filesystem remains authoritative.** Sync is one-way; markdown is still canonical and git-diffable.
3. **Opt-in everything.** Default feature off. SDK is an optional dep. Env vars optional. No secrets in \`.features.json\` unless you want them there.
4. **Matches the repo's existing \`[BETA]\` vocabulary.** Onboarding question, \`.features.json\` entry shape, and README section all mirror \`memory_search_fts\`.
5. **Namespace isolation.** Multiple projects on one shared yantrikdb server don't collide — namespace is derived from a stable hash of the repo root path.

## Test plan

Because the repo doesn't currently have a pytest suite, I've gone the \`examples/\` route for smoke-verifiability. Reviewers can exercise the happy path with:

- [x] Fork clones clean, no binary/pyc artifacts committed (\`__pycache__/\` remains gitignored)
- [x] All new/modified Python files pass \`python -m py_compile\`
- [x] Onboarding \`--yes\` path still works (extra feature defaults to off)
- [ ] Onboarding interactive path (manual — adds one question to the wizard)
- [ ] \`pip install 'yantrikdb-client[embed]>=0.2.1'\` + run \`examples/yantrikdb_quickstart.py\` against a local or cloud yantrikdb server
- [ ] Confirm graceful fallback: with feature disabled, \`yantrikdb_recall.py "foo"\` prints a clear message and exits with code 2

## Context

I (Pranab, [@spranab](https://github.com/spranab)) maintain yantrikdb and have been using agentic-stack across projects. You mentioned a PR would be welcome when I asked about adding yantrikdb — this is that PR, with a scope aimed at useful-without-being-invasive.

Happy to split this into multiple smaller PRs if you'd prefer (e.g. land just \`yantrikdb_sync.py\` + docs first, then recall + reflect in a follow-up), or to drop any piece that feels out of scope. Also happy to rework the onboarding question wording, file placement, or default flags to match your preferences.

## Follow-ups (not in this PR)

- \`yantrikdb_think.py\` — trigger consolidation + conflict scans on the yantrikdb server
- Write-back from yantrikdb → filesystem markdown
- Tombstoning records on deletion during \`--full\` sync
- Full pytest suite once you decide on a preferred test framework

🤖 Generated with [Claude Code](https://claude.com/claude-code)