### PR TITLE
feat(harness-manager): v0.9.0 manifest-driven adapter system + closes #18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,23 @@ Existing v0.8.x users: `brew upgrade agentic-stack`, then run
 adapters from filesystem signals and asks before writing `install.json`.
 Subsequent doctor runs are read-only.
 
+### Release checklist (post-merge, pre-`brew upgrade`)
+The Homebrew Formula (`Formula/agentic-stack.rb`) intentionally still
+points at the v0.8.0 tarball in this PR. The v0.9.0 release flow is:
+
+1. Merge this PR to master.
+2. Tag `v0.9.0` on master and create the GitHub release.
+3. Run `curl -L https://github.com/codejunkie99/agentic-stack/archive/refs/tags/v0.9.0.tar.gz | shasum -a 256` to compute the new sha256.
+4. Open a follow-up PR that updates `url`, `sha256`, `version` together,
+   and adds `harness_manager` + `install.ps1` to the `pkgshare.install` line.
+   This is the same pattern as commit `abaa352` (the v0.8.0 sha256 bump).
+
+Reason for the split: a Formula change that adds `harness_manager/` to
+`pkgshare.install` while still pointing at the v0.8.0 tarball would fail
+brew install (file-not-found in the staged tarball). Bumping all four
+fields together as a follow-up after the tag exists keeps the formula
+always pointing at a real, installable artifact.
+
 ## [0.8.0] — 2026-04-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,60 @@ All notable changes to this project.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] — 2026-04-23
+
+### Added
+- **Harness manager: manifest-driven adapter system.** Each adapter now
+  ships an `adapters/<name>/adapter.json` declaring its files,
+  collision policy, optional skills directory mirror, and named
+  post-install actions. Adding a new adapter is now a JSON-only PR —
+  no Python code, no test wiring, no class registration. Lives in the
+  new `harness_manager/` Python package.
+- **`./install.sh add <adapter>`** — append an adapter to an existing
+  project without re-running the onboarding wizard.
+- **`./install.sh remove <adapter>`** — confirmation prompt lists every
+  file before deletion. Hard delete (no quarantine, no undo — git is
+  the safety net). Reverses post-install actions automatically (e.g.,
+  `openclaw agents remove`).
+- **`./install.sh doctor`** — read-only audit of installed adapters.
+  Verifies tracked files exist, post-install state is valid, `.agent/`
+  brain is intact. Exits 0 on green, 1 on red. First run on a
+  pre-v0.9.0 project asks before synthesizing `install.json` — never
+  silently mutates.
+- **`./install.sh status`** — one-screen view of installed adapters,
+  brain stats (skills/episodic/lessons), last-updated timestamp.
+- **`.agent/install.json`** — authoritative record of what's installed.
+  Schema-versioned. Atomic write via tempfile + rename, fcntl-locked
+  on POSIX.
+- **PowerShell parity from day one.** `install.ps1` is now a 70-line
+  thin dispatcher to the same Python backend `install.sh` uses. The
+  new `add`/`remove`/`doctor`/`status` verbs behave identically across
+  mac/Linux/Windows. Was 270+ lines of duplicated bash-shaped logic.
+- `docs/per-harness/standalone-python.md` — gap-fill for the only
+  harness that didn't have a per-harness doc.
+
+### Fixed
+- **#18** — Claude Code hook commands break when cwd is not the
+  project root. `adapters/claude-code/settings.json` template now uses
+  `{{BRAIN_ROOT}}` placeholder, which the manifest backend substitutes
+  with `$CLAUDE_PROJECT_DIR` at install time. Hook commands resolve
+  correctly regardless of which directory Claude Code's cwd points at.
+  Thanks to @palamp for the report and the proposal that shaped the
+  larger feature.
+
+### Changed
+- `install.sh` shrinks from 175 lines of bash case-statements to 35
+  lines of dispatcher. All install logic moved to `harness_manager/`.
+  Existing CLI surface preserved: `./install.sh <adapter> [target]
+  [--yes|--reconfigure|--force]` works identically.
+- `install.ps1` shrinks from 270+ lines to 70.
+
+### Migration
+Existing v0.8.x users: `brew upgrade agentic-stack`, then run
+`./install.sh doctor` in your project. Doctor detects existing
+adapters from filesystem signals and asks before writing `install.json`.
+Subsequent doctor runs are read-only.
+
 ## [0.8.0] — 2026-04-21
 
 ### Added

--- a/Formula/agentic-stack.rb
+++ b/Formula/agentic-stack.rb
@@ -7,8 +7,11 @@ class AgenticStack < Formula
   license "Apache-2.0"
 
   def install
-    # install the brain + adapters alongside install.sh so relative paths hold
-    pkgshare.install ".agent", "adapters", "install.sh",
+    # install the brain + adapters alongside install.sh so relative paths hold.
+    # harness_manager/ is the v0.9.0 Python backend that install.sh dispatches
+    # into; without it brewed users hit ModuleNotFoundError on first install.
+    pkgshare.install ".agent", "adapters", "install.sh", "install.ps1",
+                     "harness_manager",
                      "onboard.py", "onboard_ui.py", "onboard_widgets.py",
                      "onboard_render.py", "onboard_write.py",
                      "onboard_features.py"

--- a/Formula/agentic-stack.rb
+++ b/Formula/agentic-stack.rb
@@ -1,23 +1,14 @@
 class AgenticStack < Formula
   desc "One brain, many harnesses — portable .agent/ folder for AI coding agents"
   homepage "https://github.com/codejunkie99/agentic-stack"
-  # NOTE: sha256 must be updated after the v0.9.0 GitHub release is cut.
-  # The url/sha256 chicken-and-egg is the same pattern as the v0.8.0 release
-  # (commit abaa352 "chore: update Formula sha256 for v0.8.0 tarball" did the
-  # post-release sha256 bump). Tag v0.9.0, then run:
-  #   curl -L https://github.com/codejunkie99/agentic-stack/archive/refs/tags/v0.9.0.tar.gz | shasum -a 256
-  # and replace the placeholder below.
-  url "https://github.com/codejunkie99/agentic-stack/archive/refs/tags/v0.9.0.tar.gz"
-  sha256 "0000000000000000000000000000000000000000000000000000000000000000"  # TODO: update post-tag
-  version "0.9.0"
+  url "https://github.com/codejunkie99/agentic-stack/archive/refs/tags/v0.8.0.tar.gz"
+  sha256 "7b26dbea6ff28eb3561c6a6514021713f6e6291cabbf5a362627ff0d3464d8a0"
+  version "0.8.0"
   license "Apache-2.0"
 
   def install
-    # install the brain + adapters alongside install.sh so relative paths hold.
-    # harness_manager/ is the v0.9.0 Python backend that install.sh dispatches
-    # into; without it brewed users hit ModuleNotFoundError on first install.
-    pkgshare.install ".agent", "adapters", "install.sh", "install.ps1",
-                     "harness_manager",
+    # install the brain + adapters alongside install.sh so relative paths hold
+    pkgshare.install ".agent", "adapters", "install.sh",
                      "onboard.py", "onboard_ui.py", "onboard_widgets.py",
                      "onboard_render.py", "onboard_write.py",
                      "onboard_features.py"

--- a/Formula/agentic-stack.rb
+++ b/Formula/agentic-stack.rb
@@ -1,9 +1,15 @@
 class AgenticStack < Formula
   desc "One brain, many harnesses — portable .agent/ folder for AI coding agents"
   homepage "https://github.com/codejunkie99/agentic-stack"
-  url "https://github.com/codejunkie99/agentic-stack/archive/refs/tags/v0.8.0.tar.gz"
-  sha256 "7b26dbea6ff28eb3561c6a6514021713f6e6291cabbf5a362627ff0d3464d8a0"
-  version "0.8.0"
+  # NOTE: sha256 must be updated after the v0.9.0 GitHub release is cut.
+  # The url/sha256 chicken-and-egg is the same pattern as the v0.8.0 release
+  # (commit abaa352 "chore: update Formula sha256 for v0.8.0 tarball" did the
+  # post-release sha256 bump). Tag v0.9.0, then run:
+  #   curl -L https://github.com/codejunkie99/agentic-stack/archive/refs/tags/v0.9.0.tar.gz | shasum -a 256
+  # and replace the placeholder below.
+  url "https://github.com/codejunkie99/agentic-stack/archive/refs/tags/v0.9.0.tar.gz"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"  # TODO: update post-tag
+  version "0.9.0"
   license "Apache-2.0"
 
   def install

--- a/README.md
+++ b/README.md
@@ -55,6 +55,22 @@ cd agentic-stack && ./install.sh claude-code         # mac / linux / git-bash
 # adapters: claude-code | cursor | windsurf | opencode | openclaw | hermes | pi | codex | standalone-python | antigravity
 ```
 
+### Once installed: manage what's wired
+
+After the first `./install.sh <adapter>`, manage your project with
+verb-style subcommands (works with both `install.sh` and `install.ps1`):
+
+```bash
+./install.sh add cursor          # add a second adapter (Claude Code + Cursor in same repo)
+./install.sh status              # one-screen view: which adapters, brain stats
+./install.sh doctor              # read-only audit; green / yellow / red per adapter
+./install.sh remove cursor       # confirm prompt + delete; no quarantine, no undo
+```
+
+Bare `./install.sh` (no arguments) prints the available adapters, or
+— on a project that already has an install.json — lists what's still
+installable.
+
 ## Onboarding wizard
 
 After the adapter is installed, a terminal wizard populates

--- a/adapters/antigravity/adapter.json
+++ b/adapters/antigravity/adapter.json
@@ -1,0 +1,11 @@
+{
+  "name": "antigravity",
+  "description": "Antigravity — ANTIGRAVITY.md system context.",
+  "files": [
+    {
+      "src": "ANTIGRAVITY.md",
+      "dst": "ANTIGRAVITY.md",
+      "merge_policy": "overwrite"
+    }
+  ]
+}

--- a/adapters/claude-code/adapter.json
+++ b/adapters/claude-code/adapter.json
@@ -1,0 +1,18 @@
+{
+  "name": "claude-code",
+  "description": "Claude Code (Anthropic) — CLAUDE.md instructions + .claude/settings.json PostToolUse + Stop hooks. Hook commands use $CLAUDE_PROJECT_DIR for cwd-stable resolution (closes #18).",
+  "brain_root_primitive": "$CLAUDE_PROJECT_DIR",
+  "files": [
+    {
+      "src": "CLAUDE.md",
+      "dst": "CLAUDE.md",
+      "merge_policy": "overwrite"
+    },
+    {
+      "src": "settings.json",
+      "dst": ".claude/settings.json",
+      "merge_policy": "overwrite",
+      "substitute": true
+    }
+  ]
+}

--- a/adapters/claude-code/settings.json
+++ b/adapters/claude-code/settings.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 .agent/harness/hooks/claude_code_post_tool.py"
+            "command": "python3 \"{{BRAIN_ROOT}}/.agent/harness/hooks/claude_code_post_tool.py\""
           }
         ]
       }
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 .agent/memory/auto_dream.py"
+            "command": "python3 \"{{BRAIN_ROOT}}/.agent/memory/auto_dream.py\""
           }
         ]
       }

--- a/adapters/claude-code/settings.json
+++ b/adapters/claude-code/settings.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"{{BRAIN_ROOT}}/.agent/harness/hooks/claude_code_post_tool.py\""
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.agent/harness/hooks/claude_code_post_tool.py\""
           }
         ]
       }
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"{{BRAIN_ROOT}}/.agent/memory/auto_dream.py\""
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.agent/memory/auto_dream.py\""
           }
         ]
       }

--- a/adapters/codex/adapter.json
+++ b/adapters/codex/adapter.json
@@ -1,0 +1,16 @@
+{
+  "name": "codex",
+  "description": "OpenAI Codex CLI — AGENTS.md + .agents/skills mirror (Codex's documented skills directory per https://developers.openai.com/codex/skills).",
+  "files": [
+    {
+      "src": "AGENTS.md",
+      "dst": "AGENTS.md",
+      "merge_policy": "merge_or_alert"
+    }
+  ],
+  "skills_link": {
+    "target": ".agent/skills",
+    "dst": ".agents/skills",
+    "fallback": "rsync_with_delete"
+  }
+}

--- a/adapters/cursor/adapter.json
+++ b/adapters/cursor/adapter.json
@@ -1,0 +1,11 @@
+{
+  "name": "cursor",
+  "description": "Cursor — .cursor/rules instruction text. No executable hooks; AI runs commands from project root cwd.",
+  "files": [
+    {
+      "src": ".cursor/rules/agentic-stack.mdc",
+      "dst": ".cursor/rules/agentic-stack.mdc",
+      "merge_policy": "overwrite"
+    }
+  ]
+}

--- a/adapters/hermes/adapter.json
+++ b/adapters/hermes/adapter.json
@@ -1,0 +1,11 @@
+{
+  "name": "hermes",
+  "description": "Hermes Agent (Nous Research) — AGENTS.md workspace context. agentskills.io-compatible.",
+  "files": [
+    {
+      "src": "AGENTS.md",
+      "dst": "AGENTS.md",
+      "merge_policy": "merge_or_alert"
+    }
+  ]
+}

--- a/adapters/openclaw/adapter.json
+++ b/adapters/openclaw/adapter.json
@@ -1,0 +1,17 @@
+{
+  "name": "openclaw",
+  "description": "OpenClaw — AGENTS.md auto-injection + per-project agent registration via `openclaw agents add --workspace`. Falls back to system-prompt include on forks without `agents add`.",
+  "files": [
+    {
+      "src": "AGENTS.md",
+      "dst": "AGENTS.md",
+      "merge_policy": "merge_or_alert"
+    },
+    {
+      "src": "config.md",
+      "dst": ".openclaw-system.md",
+      "merge_policy": "overwrite"
+    }
+  ],
+  "post_install": ["openclaw_register_workspace"]
+}

--- a/adapters/opencode/adapter.json
+++ b/adapters/opencode/adapter.json
@@ -1,0 +1,16 @@
+{
+  "name": "opencode",
+  "description": "OpenCode — AGENTS.md (with collision protection) + opencode.json permission rules.",
+  "files": [
+    {
+      "src": "AGENTS.md",
+      "dst": "AGENTS.md",
+      "merge_policy": "merge_or_alert"
+    },
+    {
+      "src": "opencode.json",
+      "dst": "opencode.json",
+      "merge_policy": "overwrite"
+    }
+  ]
+}

--- a/adapters/pi/adapter.json
+++ b/adapters/pi/adapter.json
@@ -1,0 +1,27 @@
+{
+  "name": "pi",
+  "description": "Pi Coding Agent — AGENTS.md + .pi/skills symlink + .pi/extensions/memory-hook.ts (TS extension that calls .agent/harness/hooks/pi_post_tool.py for tool_result episodic logging).",
+  "files": [
+    {
+      "src": "AGENTS.md",
+      "dst": "AGENTS.md",
+      "merge_policy": "skip_if_exists"
+    },
+    {
+      "src": "memory-hook.ts",
+      "dst": ".pi/extensions/memory-hook.ts",
+      "merge_policy": "overwrite"
+    },
+    {
+      "src": ".agent/harness/hooks/pi_post_tool.py",
+      "dst": ".agent/harness/hooks/pi_post_tool.py",
+      "merge_policy": "overwrite",
+      "from_stack": true
+    }
+  ],
+  "skills_link": {
+    "target": ".agent/skills",
+    "dst": ".pi/skills",
+    "fallback": "rsync_with_delete"
+  }
+}

--- a/adapters/standalone-python/adapter.json
+++ b/adapters/standalone-python/adapter.json
@@ -1,0 +1,11 @@
+{
+  "name": "standalone-python",
+  "description": "Standalone Python — DIY conductor entrypoint (run.py). Does not overwrite existing run.py (user customizations preserved).",
+  "files": [
+    {
+      "src": "run.py",
+      "dst": "run.py",
+      "merge_policy": "skip_if_exists"
+    }
+  ]
+}

--- a/adapters/windsurf/adapter.json
+++ b/adapters/windsurf/adapter.json
@@ -1,0 +1,11 @@
+{
+  "name": "windsurf",
+  "description": "Windsurf — .windsurfrules instruction text. No hooks today.",
+  "files": [
+    {
+      "src": ".windsurfrules",
+      "dst": ".windsurfrules",
+      "merge_policy": "overwrite"
+    }
+  ]
+}

--- a/docs/per-harness/standalone-python.md
+++ b/docs/per-harness/standalone-python.md
@@ -1,0 +1,57 @@
+# Standalone Python setup
+
+## What the adapter installs
+- `run.py` at project root — a DIY conductor entrypoint you can edit
+  freely. Skipped on re-install if you already have one (your edits
+  are preserved).
+
+## Install
+```bash
+./install.sh standalone-python
+```
+
+Or on Windows:
+```powershell
+.\install.ps1 standalone-python
+```
+
+## How it works
+Standalone Python is the "no harness" path. You write your own loop
+that drives an LLM (any provider — Anthropic, OpenAI, Ollama, etc.)
+and uses `.agent/` as the brain. The shipped `run.py` is a starting
+template; you're expected to adapt it to your provider, prompt
+format, and tool set.
+
+The portable brain (`.agent/`) works the same as with any other
+harness: read `AGENTS.md` first, log via
+`python3 .agent/tools/memory_reflect.py`, recall via
+`python3 .agent/tools/recall.py`, etc.
+
+## Verify
+After install, the directory structure looks like:
+
+```
+your-project/
+├── .agent/                       # portable brain
+└── run.py                        # your conductor entrypoint
+```
+
+Run `python3 run.py` (or whatever you customize it to). It should at
+minimum read AGENTS.md and surface lessons before acting.
+
+## Why no hook support
+Standalone Python is full control by definition. You wire whatever
+hooks you want directly — call `log_execution()` from `.agent/harness/hooks/`
+where it makes sense in your loop. The adapter ships no settings.json
+or extension config because there's no harness to configure.
+
+## Audit
+After install, `./install.sh doctor` will report `standalone-python`
+as installed (signal: `run.py` present). Doctor doesn't check the
+content of `run.py` since it's user-customized.
+
+## Re-install
+`./install.sh standalone-python` on a project that already has
+`run.py` is a no-op for `run.py` itself (`merge_policy: skip_if_exists`).
+The `.agent/` brain is also left alone if already present. Safe
+to re-run.

--- a/harness_manager/__init__.py
+++ b/harness_manager/__init__.py
@@ -1,0 +1,8 @@
+"""harness_manager — manifest-driven adapter installer for agentic-stack.
+
+This package is the implementation backend for `./install.sh` and `./install.ps1`.
+The user-facing surface is plain verbs: install, add, remove, doctor, status.
+The "harness_manager" name is internal only and never appears in CLI help, docs,
+or error messages users see.
+"""
+__version__ = "0.9.0"

--- a/harness_manager/cli.py
+++ b/harness_manager/cli.py
@@ -19,7 +19,7 @@ from . import status as status_mod
 from . import __version__
 
 
-VERBS = {"add", "remove", "doctor", "status"}
+VERBS = {"add", "remove", "doctor", "status", "manage"}
 
 
 def _stack_root() -> Path:
@@ -163,6 +163,23 @@ def cmd_status(target: Path) -> int:
     return status_mod.show(target_root=target)
 
 
+def cmd_manage(target: Path) -> int:
+    """Open the persistent TUI menu for ongoing adapter management."""
+    if not sys.stdin.isatty() or not sys.stdout.isatty():
+        print(
+            "error: manage is an interactive TUI; this shell is not a TTY.\n"
+            "use the verb-style subcommands instead:\n"
+            "  ./install.sh add <adapter>\n"
+            "  ./install.sh remove <adapter>\n"
+            "  ./install.sh doctor\n"
+            "  ./install.sh status",
+            file=sys.stderr,
+        )
+        return 2
+    from . import manage_tui
+    return manage_tui.run(target_root=target, stack_root=_stack_root())
+
+
 def cmd_bare(target: Path) -> int:
     """`./install.sh` with no args.
 
@@ -178,6 +195,8 @@ def cmd_bare(target: Path) -> int:
         print("  ./install.sh doctor      # audit")
         print("  ./install.sh status      # quick read-only view")
         print("  ./install.sh add <name>  # install another adapter")
+        print("  ./install.sh remove <name>  # remove an adapter (with confirm)")
+        print("  ./install.sh manage      # interactive TUI for everything")
         return 2
 
     installed = set(doc.get("adapters", {}).keys())
@@ -253,6 +272,9 @@ def main(argv: list[str] | None = None) -> int:
         if verb == "status":
             target = Path(rest[1]) if len(rest) >= 2 else Path.cwd()
             return cmd_status(target)
+        if verb == "manage":
+            target = Path(rest[1]) if len(rest) >= 2 else Path.cwd()
+            return cmd_manage(target)
 
     # Treat as adapter name (existing UX)
     adapter = first

--- a/harness_manager/cli.py
+++ b/harness_manager/cli.py
@@ -111,7 +111,36 @@ def cmd_install(adapter_name: str, target: Path, wizard_flags: list[str]) -> int
 
 
 def cmd_add(adapter_name: str, target: Path) -> int:
-    """Append one adapter to an existing project (no onboard wizard re-run)."""
+    """Append one adapter to an existing project (no onboard wizard re-run).
+
+    Refuses on pre-v0.9 projects (no install.json yet). Without this check,
+    `add` would create a fresh install.json with ONLY the new adapter, and
+    every adapter previously installed via the old install.sh would
+    disappear from status/doctor/remove tracking even though their files
+    are still on disk.
+    """
+    if state_mod.load(target) is None:
+        # Pre-v0.9 project. Detect adapters and refuse with a clear path forward.
+        from . import doctor as doctor_mod
+        signals_present = []
+        for name, signals in doctor_mod.DETECT_SIGNALS.items():
+            if any((target / f).exists() for f, _ in signals):
+                signals_present.append(name)
+        if signals_present:
+            print(
+                f"error: {target}/.agent/install.json not present, but these adapters\n"
+                f"appear to already be installed: {sorted(signals_present)}\n"
+                f"\n"
+                f"run this first to register them safely:\n"
+                f"  ./install.sh doctor\n"
+                f"\n"
+                f"`add` would otherwise create a fresh install.json with only\n"
+                f"the new adapter, leaving the existing ones invisible to\n"
+                f"status/doctor/remove.",
+                file=sys.stderr,
+            )
+            return 2
+        # No prior install detected; safe to proceed (`add` on a clean repo).
     manifest = _adapter_manifest(adapter_name)
     install_mod.install(
         manifest=manifest,

--- a/harness_manager/cli.py
+++ b/harness_manager/cli.py
@@ -1,0 +1,220 @@
+"""Argparse dispatcher. install.sh and install.ps1 invoke this.
+
+Verbs (subcommands): add, remove, doctor, status.
+Anything else in first position → treated as an adapter name (existing
+`./install.sh <adapter>` UX preserved).
+"""
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from . import doctor as doctor_mod
+from . import install as install_mod
+from . import remove as remove_mod
+from . import schema as schema_mod
+from . import state as state_mod
+from . import status as status_mod
+from . import __version__
+
+
+VERBS = {"add", "remove", "doctor", "status"}
+
+
+def _stack_root() -> Path:
+    """Path to the agentic-stack source root.
+
+    Honors AGENTIC_STACK_ROOT env override (CI / non-standard installs).
+    Otherwise: walk up from this file (.../harness_manager/cli.py) two
+    levels.
+    """
+    env = os.environ.get("AGENTIC_STACK_ROOT")
+    if env:
+        return Path(env).resolve()
+    return Path(__file__).resolve().parent.parent
+
+
+def _adapter_dir(adapter_name: str) -> Path:
+    return _stack_root() / "adapters" / adapter_name
+
+
+def _adapter_manifest(adapter_name: str) -> dict:
+    """Load and validate adapter.json for adapter_name."""
+    p = _adapter_dir(adapter_name) / "adapter.json"
+    if not p.is_file():
+        raise SystemExit(
+            f"error: adapter '{adapter_name}' has no adapter.json at {p}\n"
+            f"available adapters: {_list_adapters()}"
+        )
+    return schema_mod.validate(p)
+
+
+def _list_adapters() -> str:
+    root = _stack_root() / "adapters"
+    if not root.is_dir():
+        return "(adapters dir missing)"
+    names = sorted(p.name for p in root.iterdir() if p.is_dir())
+    return ", ".join(names)
+
+
+def _maybe_run_onboard(target: Path, wizard_flags: list[str]) -> None:
+    """Run onboard.py against target after install (mirrors install.sh:249).
+
+    Skipped if onboard.py missing or python3 missing (mirror of bash check).
+    """
+    onboard = _stack_root() / "onboard.py"
+    if not onboard.is_file():
+        print(
+            f"tip: customize {target}/.agent/memory/personal/PREFERENCES.md "
+            "with your conventions."
+        )
+        return
+    cmd = [sys.executable, str(onboard), str(target), *wizard_flags]
+    try:
+        subprocess.run(cmd, check=False)
+    except FileNotFoundError:
+        print(
+            "tip: python3 not found — edit "
+            ".agent/memory/personal/PREFERENCES.md manually."
+        )
+
+
+# ---- subcommands -----------------------------------------------------
+
+def cmd_install(adapter_name: str, target: Path, wizard_flags: list[str]) -> int:
+    """Install one adapter into target. Existing `./install.sh <adapter>` UX."""
+    manifest = _adapter_manifest(adapter_name)
+    install_mod.install(
+        manifest=manifest,
+        target_root=target,
+        adapter_dir=_adapter_dir(adapter_name),
+        stack_root=_stack_root(),
+    )
+    _maybe_run_onboard(target, wizard_flags)
+    return 0
+
+
+def cmd_add(adapter_name: str, target: Path) -> int:
+    """Append one adapter to an existing project (no onboard wizard re-run)."""
+    manifest = _adapter_manifest(adapter_name)
+    install_mod.install(
+        manifest=manifest,
+        target_root=target,
+        adapter_dir=_adapter_dir(adapter_name),
+        stack_root=_stack_root(),
+    )
+    return 0
+
+
+def cmd_remove(adapter_name: str, target: Path, yes: bool) -> int:
+    return remove_mod.remove(target_root=target, adapter_name=adapter_name, yes=yes)
+
+
+def cmd_doctor(target: Path) -> int:
+    return doctor_mod.audit(target_root=target)
+
+
+def cmd_status(target: Path) -> int:
+    return status_mod.show(target_root=target)
+
+
+def cmd_bare(target: Path) -> int:
+    """`./install.sh` with no args.
+
+    If install.json present: dispatch to add mode (offer adapters not yet
+    installed). If not: print usage and exit non-zero.
+    """
+    doc = state_mod.load(target)
+    if doc is None:
+        print("usage: ./install.sh <adapter-name> [target-dir]")
+        print(f"adapters: {_list_adapters()}")
+        print()
+        print("on a project that's already installed, run:")
+        print("  ./install.sh doctor      # audit")
+        print("  ./install.sh status      # quick read-only view")
+        print("  ./install.sh add <name>  # install another adapter")
+        return 2
+
+    installed = set(doc.get("adapters", {}).keys())
+    available = set()
+    root = _stack_root() / "adapters"
+    if root.is_dir():
+        for p in root.iterdir():
+            if p.is_dir() and (p / "adapter.json").is_file():
+                available.add(p.name)
+    not_installed = sorted(available - installed)
+    if not not_installed:
+        print(f"all available adapters already installed: {sorted(installed)}")
+        print("run `./install.sh status` for a summary.")
+        return 0
+
+    print(f"already installed: {sorted(installed)}")
+    print(f"available to add:  {not_installed}")
+    print()
+    print(f"to add one: ./install.sh add <name>")
+    return 0
+
+
+# ---- main ------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    if argv is None:
+        argv = sys.argv[1:]
+
+    # Extract --yes / --reconfigure / --force into wizard_flags; these
+    # pass through to onboard.py for back-compat with the bash flow.
+    wizard_flags: list[str] = []
+    rest: list[str] = []
+    i = 0
+    yes = False
+    while i < len(argv):
+        a = argv[i]
+        if a in ("--yes", "-y"):
+            wizard_flags.append("--yes")
+            yes = True
+        elif a == "--reconfigure":
+            wizard_flags.append("--reconfigure")
+        elif a == "--force":
+            wizard_flags.append("--force")
+        else:
+            rest.append(a)
+        i += 1
+
+    if not rest:
+        target = Path.cwd()
+        return cmd_bare(target)
+
+    first = rest[0]
+
+    if first in VERBS:
+        verb = first
+        if verb == "add":
+            if len(rest) < 2:
+                print("usage: ./install.sh add <adapter-name> [target-dir]", file=sys.stderr)
+                return 2
+            adapter = rest[1]
+            target = Path(rest[2]) if len(rest) >= 3 else Path.cwd()
+            return cmd_add(adapter, target)
+        if verb == "remove":
+            if len(rest) < 2:
+                print("usage: ./install.sh remove <adapter-name> [target-dir] [--yes]", file=sys.stderr)
+                return 2
+            adapter = rest[1]
+            target = Path(rest[2]) if len(rest) >= 3 else Path.cwd()
+            return cmd_remove(adapter, target, yes=yes)
+        if verb == "doctor":
+            target = Path(rest[1]) if len(rest) >= 2 else Path.cwd()
+            return cmd_doctor(target)
+        if verb == "status":
+            target = Path(rest[1]) if len(rest) >= 2 else Path.cwd()
+            return cmd_status(target)
+
+    # Treat as adapter name (existing UX)
+    adapter = first
+    target = Path(rest[1]) if len(rest) >= 2 else Path.cwd()
+    return cmd_install(adapter, target, wizard_flags)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/harness_manager/cli.py
+++ b/harness_manager/cli.py
@@ -58,10 +58,15 @@ def _list_adapters() -> str:
     return ", ".join(names)
 
 
-def _maybe_run_onboard(target: Path, wizard_flags: list[str]) -> None:
+def _maybe_run_onboard(target: Path, wizard_flags: list[str]) -> int:
     """Run onboard.py against target after install (mirrors install.sh:249).
 
-    Skipped if onboard.py missing or python3 missing (mirror of bash check).
+    Returns the wizard's exit code so cmd_install can propagate failures
+    (Ctrl-C in the wizard, exception in onboard.py, etc.). Pre-v0.9.0
+    install.sh did `exec python3 onboard.py` so failures naturally
+    flowed up — this preserves that contract for CI / scripted users.
+
+    Returns 0 if onboard.py or python3 is missing (matches bash tip-and-skip).
     """
     onboard = _stack_root() / "onboard.py"
     if not onboard.is_file():
@@ -69,15 +74,23 @@ def _maybe_run_onboard(target: Path, wizard_flags: list[str]) -> None:
             f"tip: customize {target}/.agent/memory/personal/PREFERENCES.md "
             "with your conventions."
         )
-        return
+        return 0
     cmd = [sys.executable, str(onboard), str(target), *wizard_flags]
     try:
-        subprocess.run(cmd, check=False)
+        result = subprocess.run(cmd, check=False)
+        return result.returncode
     except FileNotFoundError:
         print(
             "tip: python3 not found — edit "
             ".agent/memory/personal/PREFERENCES.md manually."
         )
+        return 0
+    except KeyboardInterrupt:
+        # User Ctrl-C'd the wizard. Treat as a real failure so callers
+        # know the install is incomplete.
+        print()
+        print("onboarding cancelled by user; install state may be partial.")
+        return 130
 
 
 # ---- subcommands -----------------------------------------------------
@@ -91,8 +104,10 @@ def cmd_install(adapter_name: str, target: Path, wizard_flags: list[str]) -> int
         adapter_dir=_adapter_dir(adapter_name),
         stack_root=_stack_root(),
     )
-    _maybe_run_onboard(target, wizard_flags)
-    return 0
+    # Propagate the onboarding wizard's exit code: Ctrl-C, exception, or
+    # explicit failure inside onboard.py should fail the install command,
+    # matching the pre-v0.9.0 `exec python3 onboard.py` semantics.
+    return _maybe_run_onboard(target, wizard_flags)
 
 
 def cmd_add(adapter_name: str, target: Path) -> int:

--- a/harness_manager/cli.py
+++ b/harness_manager/cli.py
@@ -96,7 +96,37 @@ def _maybe_run_onboard(target: Path, wizard_flags: list[str]) -> int:
 # ---- subcommands -----------------------------------------------------
 
 def cmd_install(adapter_name: str, target: Path, wizard_flags: list[str]) -> int:
-    """Install one adapter into target. Existing `./install.sh <adapter>` UX."""
+    """Install one adapter into target. Existing `./install.sh <adapter>` UX.
+
+    Refuses on pre-v0.9 projects (no install.json) when STRONG adapter
+    signals are already on disk — without this guard, the install would
+    create a fresh install.json containing only the newly-installed
+    adapter, orphaning every pre-v0.9 install (they'd vanish from
+    status/doctor/remove even though their files remain on disk). The
+    same gate cmd_add uses. Weak signals (plain CLAUDE.md, AGENTS.md,
+    run.py) are ignored to avoid false-refusing clean repos that happen
+    to contain one of those common files.
+    """
+    detected = state_mod.legacy_unregistered_adapters(target)
+    if detected:
+        # Pre-v0.9 project: brain is present AND adapter signals exist.
+        # Refuse so doctor can synthesize install.json first and
+        # preserve the prior install(s). Brain-without-signals is NOT
+        # gated — cloning agentic-stack itself, or copying the brain
+        # template before first install, shouldn't deadlock the user.
+        print(
+            f"error: {target}/.agent/ exists but install.json does not.\n"
+            f"this looks like a pre-v0.9 install. detected adapters: {detected}\n"
+            f"\n"
+            f"run this first to register them safely:\n"
+            f"  ./install.sh doctor\n"
+            f"\n"
+            f"proceeding would otherwise create a fresh install.json with only\n"
+            f"the new adapter, leaving the existing ones invisible to\n"
+            f"status/doctor/remove.",
+            file=sys.stderr,
+        )
+        return 2
     manifest = _adapter_manifest(adapter_name)
     install_mod.install(
         manifest=manifest,
@@ -107,7 +137,51 @@ def cmd_install(adapter_name: str, target: Path, wizard_flags: list[str]) -> int
     # Propagate the onboarding wizard's exit code: Ctrl-C, exception, or
     # explicit failure inside onboard.py should fail the install command,
     # matching the pre-v0.9.0 `exec python3 onboard.py` semantics.
-    return _maybe_run_onboard(target, wizard_flags)
+    rc = _maybe_run_onboard(target, wizard_flags)
+    if rc != 0:
+        return rc
+    # Post-install: offer the manage TUI so users who installed one
+    # adapter can immediately add others without re-running install.sh.
+    # Skip if --yes (scripted) or non-TTY (CI safety).
+    if "--yes" not in wizard_flags and sys.stdin.isatty() and sys.stdout.isatty():
+        _maybe_offer_manage(target)
+    return 0
+
+
+def _maybe_offer_manage(target: Path) -> None:
+    """Offer the manage TUI after a single-adapter install.
+
+    Only invoked from cmd_install when the shell is interactive and the
+    user didn't pass --yes. If every available adapter is already
+    installed, skip the prompt — nothing useful to do in the TUI. Default
+    is no, so just hitting enter dismisses without entering the TUI.
+    """
+    doc = state_mod.load(target) or {}
+    installed = set(doc.get("adapters") or {})
+    available = set()
+    root = _stack_root() / "adapters"
+    if root.is_dir():
+        for p in root.iterdir():
+            if p.is_dir() and (p / "adapter.json").is_file():
+                available.add(p.name)
+    not_installed = sorted(available - installed)
+    if not not_installed:
+        return
+    sys.path.insert(0, str(_stack_root()))
+    import onboard_widgets as widgets  # noqa: E402
+    print()
+    try:
+        choice = widgets.ask_confirm(
+            f"install or manage other adapters? ({len(not_installed)} available)",
+            default=False,
+        )
+    except KeyboardInterrupt:
+        # Install already succeeded; treat Ctrl-C at the offer as "no."
+        print()
+        return
+    if choice:
+        from . import manage_tui
+        manage_tui.run(target_root=target, stack_root=_stack_root())
 
 
 def cmd_add(adapter_name: str, target: Path) -> int:
@@ -119,28 +193,21 @@ def cmd_add(adapter_name: str, target: Path) -> int:
     disappear from status/doctor/remove tracking even though their files
     are still on disk.
     """
-    if state_mod.load(target) is None:
-        # Pre-v0.9 project. Detect adapters and refuse with a clear path forward.
-        from . import doctor as doctor_mod
-        signals_present = []
-        for name, signals in doctor_mod.DETECT_SIGNALS.items():
-            if any((target / f).exists() for f, _ in signals):
-                signals_present.append(name)
-        if signals_present:
-            print(
-                f"error: {target}/.agent/install.json not present, but these adapters\n"
-                f"appear to already be installed: {sorted(signals_present)}\n"
-                f"\n"
-                f"run this first to register them safely:\n"
-                f"  ./install.sh doctor\n"
-                f"\n"
-                f"`add` would otherwise create a fresh install.json with only\n"
-                f"the new adapter, leaving the existing ones invisible to\n"
-                f"status/doctor/remove.",
-                file=sys.stderr,
-            )
-            return 2
-        # No prior install detected; safe to proceed (`add` on a clean repo).
+    detected = state_mod.legacy_unregistered_adapters(target)
+    if detected:
+        print(
+            f"error: {target}/.agent/ exists but install.json does not.\n"
+            f"this looks like a pre-v0.9 install. detected adapters: {detected}\n"
+            f"\n"
+            f"run this first to register them safely:\n"
+            f"  ./install.sh doctor\n"
+            f"\n"
+            f"`add` would otherwise create a fresh install.json with only\n"
+            f"the new adapter, leaving the existing ones invisible to\n"
+            f"status/doctor/remove.",
+            file=sys.stderr,
+        )
+        return 2
     manifest = _adapter_manifest(adapter_name)
     install_mod.install(
         manifest=manifest,
@@ -180,43 +247,151 @@ def cmd_manage(target: Path) -> int:
     return manage_tui.run(target_root=target, stack_root=_stack_root())
 
 
-def cmd_bare(target: Path) -> int:
+def cmd_bare(target: Path, wizard_flags: list[str]) -> int:
     """`./install.sh` with no args.
 
-    If install.json present: dispatch to add mode (offer adapters not yet
-    installed). If not: print usage and exit non-zero.
+    Behavior:
+      - install.json present  → list what's still installable
+      - no install.json + TTY → enter the onboarding wizard (multi-select
+        harness step, then per-adapter install, then PREFERENCES.md flow)
+      - no install.json + non-TTY → print usage and exit 2 (CI safety)
     """
     doc = state_mod.load(target)
-    if doc is None:
-        print("usage: ./install.sh <adapter-name> [target-dir]")
-        print(f"adapters: {_list_adapters()}")
+    if doc is not None:
+        installed = set(doc.get("adapters", {}).keys())
+        available = set()
+        root = _stack_root() / "adapters"
+        if root.is_dir():
+            for p in root.iterdir():
+                if p.is_dir() and (p / "adapter.json").is_file():
+                    available.add(p.name)
+        not_installed = sorted(available - installed)
+        if not not_installed:
+            print(f"all available adapters already installed: {sorted(installed)}")
+            print("run `./install.sh status` for a summary.")
+            return 0
+        print(f"already installed: {sorted(installed)}")
+        print(f"available to add:  {not_installed}")
         print()
-        print("on a project that's already installed, run:")
-        print("  ./install.sh doctor      # audit")
-        print("  ./install.sh status      # quick read-only view")
-        print("  ./install.sh add <name>  # install another adapter")
-        print("  ./install.sh remove <name>  # remove an adapter (with confirm)")
-        print("  ./install.sh manage      # interactive TUI for everything")
-        return 2
-
-    installed = set(doc.get("adapters", {}).keys())
-    available = set()
-    root = _stack_root() / "adapters"
-    if root.is_dir():
-        for p in root.iterdir():
-            if p.is_dir() and (p / "adapter.json").is_file():
-                available.add(p.name)
-    not_installed = sorted(available - installed)
-    if not not_installed:
-        print(f"all available adapters already installed: {sorted(installed)}")
-        print("run `./install.sh status` for a summary.")
+        print(f"to add one: ./install.sh add <name>")
+        print(f"or interactively: ./install.sh manage")
         return 0
 
-    print(f"already installed: {sorted(installed)}")
-    print(f"available to add:  {not_installed}")
+    # No install.json. Pre-v0.9 migration gate: if this is a legacy
+    # install (brain AND adapter signals present) we must register
+    # via doctor first. Brain-only (no signals) falls through to the
+    # wizard — someone dropped the template here but never installed
+    # anything, so there's nothing to migrate.
+    detected = state_mod.legacy_unregistered_adapters(target)
+    if detected:
+        print(
+            f"pre-v0.9 install detected at {target}.",
+            file=sys.stderr,
+        )
+        print(
+            f".agent/ exists but install.json does not. detected adapters: "
+            f"{detected}",
+            file=sys.stderr,
+        )
+        print(file=sys.stderr)
+        print(
+            "run this first to register them safely:", file=sys.stderr,
+        )
+        print("  ./install.sh doctor", file=sys.stderr)
+        print(file=sys.stderr)
+        print(
+            "then re-run ./install.sh to add more adapters or use "
+            "./install.sh manage.",
+            file=sys.stderr,
+        )
+        return 2
+
+    # No install.json and not a legacy install — fresh project. Two paths.
+    if sys.stdin.isatty() and sys.stdout.isatty():
+        return _run_install_wizard(target, wizard_flags)
+
+    # Non-TTY (CI, scripted) → print usage, exit 2.
+    print("usage: ./install.sh <adapter-name> [target-dir]")
+    print(f"adapters: {_list_adapters()}")
     print()
-    print(f"to add one: ./install.sh add <name>")
-    return 0
+    print("on a project that's already installed, run:")
+    print("  ./install.sh doctor      # audit")
+    print("  ./install.sh status      # quick read-only view")
+    print("  ./install.sh add <name>  # install another adapter")
+    print("  ./install.sh remove <name>  # remove an adapter (with confirm)")
+    print("  ./install.sh manage      # interactive TUI for everything")
+    return 2
+
+
+def _run_install_wizard(target: Path, wizard_flags: list[str]) -> int:
+    """Onboarding wizard: detect → multi-select → install each → PREFERENCES.md.
+
+    The original "give people options like Claude Code and all of that"
+    flow. Reuses the manage TUI's multi-select widget for harness pick.
+    Auto-checks adapters whose detection signals are present in `target`,
+    so a user who already has CLAUDE.md / .cursor/ in their repo gets
+    those pre-selected.
+    """
+    # Lazy imports — wizard path only.
+    sys.path.insert(0, str(_stack_root()))
+    import onboard_widgets as widgets  # noqa: E402
+    from onboard_ui import print_banner, intro, R, MUTED, GREEN  # noqa: E402
+    from . import doctor as doctor_mod
+
+    print_banner()
+    intro("agentic-stack onboarding")
+
+    # Discover all available adapters.
+    available = sorted(n for n, _ in schema_mod.discover_all(_stack_root()))
+    if not available:
+        print(f"  {MUTED}no adapters available — repo seems empty{R}")
+        return 1
+
+    # Auto-detect what's already on disk in the target. Only STRONG
+    # signals count for default-check — a weak signal like a generic
+    # CLAUDE.md, AGENTS.md, or run.py can belong to any project; pre-
+    # checking one and hitting Enter at the multiselect would silently
+    # overwrite the user's file (claude-code's CLAUDE.md is
+    # merge_policy: overwrite). Weak-only matches still surface to the
+    # user via the adapter list but stay unchecked until toggled.
+    detected = set()
+    for name in available:
+        signals = doctor_mod.DETECT_SIGNALS.get(name, [])
+        if any(
+            (target / f).exists()
+            for f, strength in signals
+            if strength == "strong"
+        ):
+            detected.add(name)
+    defaults = [available.index(n) for n in available if n in detected]
+
+    if detected:
+        print(f"  {GREEN}detected{R}: {sorted(detected)} — pre-checked below.")
+        print()
+
+    chosen = widgets.ask_multiselect(
+        "which harnesses are you using?",
+        available,
+        defaults=defaults,
+    )
+    if not chosen:
+        print(f"  {MUTED}no adapters selected; brain not installed.{R}")
+        print(f"  {MUTED}you can run `./install.sh <adapter>` later.{R}")
+        return 0
+
+    # Install each selected adapter via the manifest backend.
+    for name in chosen:
+        manifest_path = _stack_root() / "adapters" / name / "adapter.json"
+        manifest = schema_mod.validate(manifest_path)
+        install_mod.install(
+            manifest=manifest,
+            target_root=target,
+            adapter_dir=_stack_root() / "adapters" / name,
+            stack_root=_stack_root(),
+        )
+
+    # Continue to existing PREFERENCES.md flow.
+    return _maybe_run_onboard(target, wizard_flags)
 
 
 # ---- main ------------------------------------------------------------
@@ -246,7 +421,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if not rest:
         target = Path.cwd()
-        return cmd_bare(target)
+        return cmd_bare(target, wizard_flags)
 
     first = rest[0]
 

--- a/harness_manager/doctor.py
+++ b/harness_manager/doctor.py
@@ -131,27 +131,49 @@ def _audit_adapter(
             lines.append(f"skills_link {sl['dst']} dangles")
             return RED, lines
 
-    # Check post_install state
+    # Check post_install state. Only verify external state for actions that
+    # actually succeeded — if registration was skipped at install time
+    # (binary_missing, failed, etc.), the recorded result IS the source of
+    # truth and there's nothing on-disk to verify against.
     for r in entry.get("post_install_results", []):
         action = r.get("action", "?")
         st = r.get("status", "?")
         if action == "openclaw_register_workspace":
             agent = r.get("agent_name", "?")
-            check_status = _check_openclaw_agent(agent)
-            if check_status == "ok":
-                lines.append(f"openclaw agent '{agent}' registered")
-            elif check_status == "binary_missing":
+            if st in ("ok", "already_exists"):
+                # Registration claimed success at install time; verify it's
+                # still true. RED if the agent is now gone from openclaw config.
+                check_status = _check_openclaw_agent(agent)
+                if check_status == "ok":
+                    lines.append(f"openclaw agent '{agent}' registered")
+                elif check_status == "binary_missing":
+                    lines.append(
+                        f"openclaw agent '{agent}' was registered, but openclaw "
+                        f"binary not on PATH now — can't verify"
+                    )
+                    status_overall = max(status_overall, YELLOW, key=_status_rank)
+                elif check_status == "missing":
+                    lines.append(
+                        f"openclaw agent '{agent}' was registered, but no longer "
+                        f"present in ~/.openclaw/openclaw.json"
+                    )
+                    status_overall = RED
+            elif st == "binary_missing":
                 lines.append(
-                    f"openclaw agent '{agent}' was registered, but openclaw binary "
-                    f"not on PATH now — can't verify"
+                    f"openclaw registration skipped at install time (binary not "
+                    f"on PATH); fallback hint was printed. install with `openclaw` "
+                    f"present, or use the `--system-prompt-file` fallback."
                 )
                 status_overall = max(status_overall, YELLOW, key=_status_rank)
-            elif check_status == "missing":
+            else:
+                # Failed at install time and we recorded that. Don't escalate
+                # to red on every audit — the failure is already known and the
+                # user has a fallback hint.
                 lines.append(
-                    f"openclaw agent '{agent}' was registered, but no longer "
-                    f"present in ~/.openclaw/openclaw.json"
+                    f"openclaw registration {st} at install time "
+                    f"(see install.json for details / fallback hint)"
                 )
-                status_overall = RED
+                status_overall = max(status_overall, YELLOW, key=_status_rank)
         else:
             # Unknown post_install action — just record
             lines.append(f"post_install {action}: {st}")

--- a/harness_manager/doctor.py
+++ b/harness_manager/doctor.py
@@ -267,22 +267,68 @@ def _audit_pre_v090(target_root: Path, log: Callable[[str], None]) -> int:
             "per adapter to register explicitly.")
         return 0
 
-    # Synthesize install.json from detected adapters.
+    # Synthesize install.json from detected adapters. Crucially, walk each
+    # adapter's manifest and populate files_written / skills_link with what
+    # the old install.sh would have written. Without this, `remove` is a
+    # no-op for migrated installs (files stay on disk) and a follow-up
+    # `./install.sh add <name>` would reclassify our own files as
+    # user-owned — codex P1 caught this on the migration path.
     doc = state_mod.empty(target_root, __version__)
     now = state_mod._iso_now()  # type: ignore  # internal helper, fine here
+
+    # Defer the import to avoid circulars.
+    from . import schema as schema_mod
+
+    stack_root = Path(__file__).resolve().parent.parent
     for name, _sig in detected:
-        # Best-effort entry — files_written is empty because we don't know
-        # what was written historically. Future audits will treat this as
-        # "registered but no files tracked"; subsequent re-installs of
-        # the adapter via ./install.sh <name> will populate files_written.
-        doc["adapters"][name] = {
+        manifest_path = stack_root / "adapters" / name / "adapter.json"
+        files_written: list[str] = []
+        files_alerted: list[str] = []
+        skills_link = None
+        if manifest_path.is_file():
+            try:
+                manifest = schema_mod.validate(manifest_path)
+                # Claim ownership for files the old install.sh would have written.
+                # Skip merge_or_alert entries — the user's existing AGENTS.md
+                # may be their own content; claiming it would let us delete it.
+                for entry in manifest.get("files", []):
+                    dst = entry.get("dst")
+                    if not dst:
+                        continue
+                    if (target_root / dst).exists():
+                        if entry.get("merge_policy") == "merge_or_alert":
+                            files_alerted.append(dst)
+                        else:
+                            files_written.append(dst)
+                # Skills_link: pre-v0.9 install.sh always created this, so
+                # claim ownership (skills_link_pre_existed=False).
+                if "skills_link" in manifest:
+                    sl_dst = target_root / manifest["skills_link"]["dst"]
+                    if sl_dst.exists() or sl_dst.is_symlink():
+                        skills_link = manifest["skills_link"]
+            except Exception:
+                # If the manifest is missing or invalid, fall back to the
+                # bare-minimum entry. Doctor will still flag missing files
+                # later because there's nothing to check.
+                pass
+
+        adapter_entry = {
             "installed_at": now,
-            "files_written": [],
+            "files_written": files_written,
+            "files_overwritten": [],
+            "files_alerted": files_alerted,
             "file_results": [],
             "post_install_results": [],
             "_synthesized": True,  # marker for future migrations
         }
+        if skills_link is not None:
+            adapter_entry["skills_link"] = skills_link
+            adapter_entry["skills_link_pre_existed"] = False
+        doc["adapters"][name] = adapter_entry
+
     state_mod.save(target_root, doc)
     log(f"  ✓ wrote install.json with {len(detected)} synthesized adapter(s)")
-    log("  tip: re-run `./install.sh <adapter>` per adapter to populate files_written.")
+    if any(doc["adapters"][n].get("files_alerted") for n in doc["adapters"]):
+        log("  ! some AGENTS.md files were marked as alerted (existing content"
+            " preserved); next doctor run will check for the .agent/ marker.")
     return 0

--- a/harness_manager/doctor.py
+++ b/harness_manager/doctor.py
@@ -187,17 +187,24 @@ def _audit_adapter(
 
 
 def _check_openclaw_agent(agent_name: str) -> str:
-    """Check if openclaw agent is still registered. ok | missing | binary_missing"""
-    binary = shutil.which("openclaw")
-    if not binary:
-        return "binary_missing"
-    # Read ~/.openclaw/openclaw.json directly (faster + more deterministic
-    # than parsing `openclaw agents list` output).
+    """Check if openclaw agent is still registered. ok | missing | binary_missing
+
+    Reads ~/.openclaw/openclaw.json directly — does NOT require the
+    openclaw binary to be on PATH at audit time. The user may have
+    registered the agent on a machine where openclaw was installed,
+    then audited from a different shell where it's not. Reading the
+    config file is the source of truth either way.
+
+    Returns:
+      ok             — agent is in openclaw.json
+      missing        — openclaw.json exists but agent not in it
+      binary_missing — openclaw config file itself is absent (no install)
+    """
     try:
         import json
         cfg = Path.home() / ".openclaw" / "openclaw.json"
         if not cfg.is_file():
-            return "missing"
+            return "binary_missing"
         data = json.loads(cfg.read_text(encoding="utf-8"))
         agents = (data.get("agents") or {}).get("list") or []
         for a in agents:

--- a/harness_manager/doctor.py
+++ b/harness_manager/doctor.py
@@ -1,0 +1,237 @@
+"""Read-only audit of installed adapters.
+
+Reads .agent/install.json, verifies each adapter's tracked files still
+exist and post-install state is still valid. Reports green/yellow/red
+per adapter. Exits 0 on all-green-or-yellow, 1 on any red.
+
+First run on a pre-v0.9.0 project (no install.json) detects adapters
+from filesystem signals and ASKS before synthesizing — never silently
+writes. Codex's UX framing: doctor must not mutate without consent.
+"""
+import shutil
+import sys
+from pathlib import Path
+from typing import Callable
+
+from . import schema as schema_mod
+from . import state as state_mod
+from . import __version__
+
+
+# Detection signals: (filename, signal_strength) tuples per adapter.
+# Strong signals = file exists AND has the expected shape.
+DETECT_SIGNALS = {
+    "claude-code": [
+        ("CLAUDE.md", "weak"),
+        (".claude/settings.json", "strong"),
+    ],
+    "cursor": [(".cursor/rules/agentic-stack.mdc", "strong")],
+    "windsurf": [(".windsurfrules", "strong")],
+    "openclaw": [(".openclaw-system.md", "strong")],
+    "pi": [(".pi/extensions/memory-hook.ts", "strong")],
+    "codex": [(".agents/skills", "strong")],
+    "antigravity": [("ANTIGRAVITY.md", "strong")],
+    "opencode": [("opencode.json", "strong")],
+    "hermes": [("AGENTS.md", "weak")],  # AGENTS.md alone is ambiguous
+    "standalone-python": [("run.py", "weak")],
+}
+
+
+# ---- statuses ---------------------------------------------------------
+
+GREEN = "green"
+YELLOW = "yellow"
+RED = "red"
+
+
+def audit(target_root: Path | str, log: Callable[[str], None] | None = None) -> int:
+    """Run read-only audit. Returns exit code (0 if no red, 1 otherwise)."""
+    if log is None:
+        log = print
+
+    target_root = Path(target_root).resolve()
+    doc = state_mod.load(target_root)
+
+    if doc is None:
+        return _audit_pre_v090(target_root, log)
+
+    # install.json present → strict read-only audit
+    log(f"auditing {len(doc.get('adapters', {}))} installed adapter(s) in {target_root}")
+    log("")
+    any_red = False
+    for adapter_name in sorted(doc.get("adapters", {}).keys()):
+        entry = doc["adapters"][adapter_name]
+        status, lines = _audit_adapter(target_root, adapter_name, entry)
+        glyph = {GREEN: "✓", YELLOW: "⚠", RED: "✗"}[status]
+        log(f"{glyph} {adapter_name:18s} {status}")
+        for line in lines:
+            log(f"    {line}")
+        if status == RED:
+            any_red = True
+
+    log("")
+    log(f"summary: {_summary(doc, any_red)}")
+    return 1 if any_red else 0
+
+
+def _audit_adapter(
+    target_root: Path, adapter_name: str, entry: dict
+) -> tuple[str, list[str]]:
+    """Returns (status, list_of_detail_lines)."""
+    lines: list[str] = []
+
+    # Check tracked files exist
+    missing = []
+    for f in entry.get("files_written", []):
+        if not (target_root / f).exists():
+            missing.append(f)
+    if missing:
+        lines.append(f"missing files: {', '.join(missing)}")
+        return RED, lines
+
+    # Check skills_link target exists
+    sl = entry.get("skills_link")
+    if sl:
+        dst = target_root / sl["dst"]
+        if not dst.exists():
+            lines.append(f"skills_link {sl['dst']} missing")
+            return RED, lines
+        # If it's a symlink, check it doesn't dangle
+        if dst.is_symlink() and not dst.exists():
+            lines.append(f"skills_link {sl['dst']} dangles")
+            return RED, lines
+
+    # Check post_install state
+    status_overall = GREEN
+    for r in entry.get("post_install_results", []):
+        action = r.get("action", "?")
+        st = r.get("status", "?")
+        if action == "openclaw_register_workspace":
+            agent = r.get("agent_name", "?")
+            check_status = _check_openclaw_agent(agent)
+            if check_status == "ok":
+                lines.append(f"openclaw agent '{agent}' registered")
+            elif check_status == "binary_missing":
+                lines.append(
+                    f"openclaw agent '{agent}' was registered, but openclaw binary "
+                    f"not on PATH now — can't verify"
+                )
+                status_overall = max(status_overall, YELLOW, key=_status_rank)
+            elif check_status == "missing":
+                lines.append(
+                    f"openclaw agent '{agent}' was registered, but no longer "
+                    f"present in ~/.openclaw/openclaw.json"
+                )
+                status_overall = RED
+        else:
+            # Unknown post_install action — just record
+            lines.append(f"post_install {action}: {st}")
+
+    # .agent/ brain still intact?
+    if not (target_root / ".agent" / "AGENTS.md").is_file():
+        lines.append(".agent/AGENTS.md missing — brain not present")
+        return RED, lines
+
+    return status_overall, lines
+
+
+def _check_openclaw_agent(agent_name: str) -> str:
+    """Check if openclaw agent is still registered. ok | missing | binary_missing"""
+    binary = shutil.which("openclaw")
+    if not binary:
+        return "binary_missing"
+    # Read ~/.openclaw/openclaw.json directly (faster + more deterministic
+    # than parsing `openclaw agents list` output).
+    try:
+        import json
+        cfg = Path.home() / ".openclaw" / "openclaw.json"
+        if not cfg.is_file():
+            return "missing"
+        data = json.loads(cfg.read_text(encoding="utf-8"))
+        agents = (data.get("agents") or {}).get("list") or []
+        for a in agents:
+            if a.get("id") == agent_name:
+                return "ok"
+        return "missing"
+    except (OSError, json.JSONDecodeError):
+        return "binary_missing"
+
+
+def _status_rank(s: str) -> int:
+    return {GREEN: 0, YELLOW: 1, RED: 2}[s]
+
+
+def _summary(doc: dict, any_red: bool) -> str:
+    n = len(doc.get("adapters", {}))
+    if any_red:
+        return f"{n} adapter(s), at least 1 red — see above"
+    return f"{n} adapter(s), all green or yellow"
+
+
+# ---- pre-v0.9.0 migration prompt -------------------------------------
+
+def _audit_pre_v090(target_root: Path, log: Callable[[str], None]) -> int:
+    """No install.json. Detect adapters from filesystem and prompt to register.
+
+    Codex UX rule: never silently mutate. Show user what we found, ask Y/N,
+    write only on confirmation. On N or non-tty, exit 0 with no write.
+    """
+    detected: list[tuple[str, str]] = []  # (name, signal_strength_summary)
+    for name, signals in DETECT_SIGNALS.items():
+        present = [(f, strength) for f, strength in signals
+                   if (target_root / f).exists()]
+        if not present:
+            continue
+        strength = "strong" if any(s == "strong" for _, s in present) else "weak"
+        sig_str = ", ".join(f for f, _ in present)
+        detected.append((name, f"{strength} — {sig_str}"))
+
+    if not detected:
+        log(f"no install.json found at {target_root / '.agent/install.json'}")
+        log("no adapter signals detected either. nothing to audit.")
+        log("install an adapter with: ./install.sh <adapter-name>")
+        return 0
+
+    log(f"no install.json found at {target_root / '.agent/install.json'}")
+    log("but I see these adapters appear to be installed:")
+    log("")
+    for name, sig in detected:
+        log(f"  ✓ {name:18s} ({sig})")
+    log("")
+    log("register them in install.json so I can audit them in future runs?")
+
+    # Non-interactive (no tty) → don't prompt, just exit 0 cleanly.
+    if not sys.stdin.isatty():
+        log("(non-interactive shell; skipping. re-run from a terminal to register.)")
+        return 0
+
+    try:
+        answer = input("[Y/n]: ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        log("")
+        log("aborted; no changes written.")
+        return 0
+    if answer not in ("", "y", "yes"):
+        log("ok, leaving install.json absent. you can run `./install.sh <adapter>` "
+            "per adapter to register explicitly.")
+        return 0
+
+    # Synthesize install.json from detected adapters.
+    doc = state_mod.empty(target_root, __version__)
+    now = state_mod._iso_now()  # type: ignore  # internal helper, fine here
+    for name, _sig in detected:
+        # Best-effort entry — files_written is empty because we don't know
+        # what was written historically. Future audits will treat this as
+        # "registered but no files tracked"; subsequent re-installs of
+        # the adapter via ./install.sh <name> will populate files_written.
+        doc["adapters"][name] = {
+            "installed_at": now,
+            "files_written": [],
+            "file_results": [],
+            "post_install_results": [],
+            "_synthesized": True,  # marker for future migrations
+        }
+    state_mod.save(target_root, doc)
+    log(f"  ✓ wrote install.json with {len(detected)} synthesized adapter(s)")
+    log("  tip: re-run `./install.sh <adapter>` per adapter to populate files_written.")
+    return 0

--- a/harness_manager/doctor.py
+++ b/harness_manager/doctor.py
@@ -80,14 +80,44 @@ def _audit_adapter(
     """Returns (status, list_of_detail_lines)."""
     lines: list[str] = []
 
-    # Check tracked files exist
+    # Check all tracked files (both freshly-written and overwritten) still exist.
+    # Both categories matter for "is the adapter still wired" — only the
+    # remove-time semantics differ (overwritten files are user-owned and
+    # NOT deleted on remove).
     missing = []
-    for f in entry.get("files_written", []):
+    for f in entry.get("files_written", []) + entry.get("files_overwritten", []):
         if not (target_root / f).exists():
             missing.append(f)
     if missing:
         lines.append(f"missing files: {', '.join(missing)}")
         return RED, lines
+
+    status_overall = GREEN
+
+    # Files where install hit `merge_or_alert` and the existing file did
+    # NOT reference .agent/. The adapter is "installed" in the sense that
+    # we recorded the entry, but the brain is not actually wired until
+    # the user merges the snippet. Re-check current file content — they
+    # may have merged it since install. Yellow if still un-merged; green
+    # if they merged.
+    still_alerted = []
+    for f in entry.get("files_alerted", []):
+        p = target_root / f
+        if not p.is_file():
+            still_alerted.append(f"{f} (file missing entirely)")
+            continue
+        try:
+            content = p.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            still_alerted.append(f"{f} (unreadable)")
+            continue
+        if ".agent/" not in content:
+            still_alerted.append(f)
+    if still_alerted:
+        lines.append(
+            f"merge required: {', '.join(still_alerted)} — install printed a snippet to paste in"
+        )
+        status_overall = YELLOW
 
     # Check skills_link target exists
     sl = entry.get("skills_link")
@@ -102,7 +132,6 @@ def _audit_adapter(
             return RED, lines
 
     # Check post_install state
-    status_overall = GREEN
     for r in entry.get("post_install_results", []):
         action = r.get("action", "?")
         st = r.get("status", "?")

--- a/harness_manager/doctor.py
+++ b/harness_manager/doctor.py
@@ -285,12 +285,26 @@ def _audit_pre_v090(target_root: Path, log: Callable[[str], None]) -> int:
         files_written: list[str] = []
         files_alerted: list[str] = []
         skills_link = None
+        files_overwritten: list[str] = []
+        post_install_results: list[dict] = []
+        skills_link_pre_existed = True  # conservative default for migration
         if manifest_path.is_file():
             try:
                 manifest = schema_mod.validate(manifest_path)
-                # Claim ownership for files the old install.sh would have written.
-                # Skip merge_or_alert entries — the user's existing AGENTS.md
-                # may be their own content; claiming it would let us delete it.
+                # Migration is conservative: we don't know whether the old
+                # install.sh adopted user content (overwrite/skip_if_exists
+                # paths could have been pre-existing user files like
+                # CLAUDE.md or run.py that the old installer just clobbered).
+                # Synthesizing those as files_written would let `remove`
+                # delete genuinely-user content.
+                #
+                # Bucketing rule for synthesis:
+                #   merge_or_alert → files_alerted   (user-owned by spec)
+                #   anything else  → files_overwritten (be conservative,
+                #                                       preserve on remove)
+                #
+                # User can re-run `./install.sh <adapter>` to get strict
+                # ownership (files_written) and full remove behavior.
                 for entry in manifest.get("files", []):
                     dst = entry.get("dst")
                     if not dst:
@@ -299,13 +313,30 @@ def _audit_pre_v090(target_root: Path, log: Callable[[str], None]) -> int:
                         if entry.get("merge_policy") == "merge_or_alert":
                             files_alerted.append(dst)
                         else:
-                            files_written.append(dst)
-                # Skills_link: pre-v0.9 install.sh always created this, so
-                # claim ownership (skills_link_pre_existed=False).
+                            files_overwritten.append(dst)
+                # Skills_link: same logic. Old install.sh COULD have adopted
+                # a pre-existing dir via -L/-d. Conservative synthesis says
+                # "user-owned" so remove won't delete it. User re-installs to
+                # get strict ownership tracking.
                 if "skills_link" in manifest:
                     sl_dst = target_root / manifest["skills_link"]["dst"]
                     if sl_dst.exists() or sl_dst.is_symlink():
                         skills_link = manifest["skills_link"]
+                        # already True from default
+
+                # If this is the openclaw adapter and the agent is currently
+                # registered in ~/.openclaw/openclaw.json, recover the
+                # post_install record so a future `remove` can reverse it.
+                if name == "openclaw":
+                    from .post_install import _openclaw_agent_name
+                    expected_name = _openclaw_agent_name(target_root)
+                    check = _check_openclaw_agent(expected_name)
+                    if check == "ok":
+                        post_install_results.append({
+                            "action": "openclaw_register_workspace",
+                            "status": "ok",
+                            "agent_name": expected_name,
+                        })
             except Exception:
                 # If the manifest is missing or invalid, fall back to the
                 # bare-minimum entry. Doctor will still flag missing files
@@ -314,16 +345,16 @@ def _audit_pre_v090(target_root: Path, log: Callable[[str], None]) -> int:
 
         adapter_entry = {
             "installed_at": now,
-            "files_written": files_written,
-            "files_overwritten": [],
+            "files_written": files_written,           # always [] for synthesized
+            "files_overwritten": files_overwritten,   # all non-merge_or_alert files (conservative)
             "files_alerted": files_alerted,
             "file_results": [],
-            "post_install_results": [],
+            "post_install_results": post_install_results,
             "_synthesized": True,  # marker for future migrations
         }
         if skills_link is not None:
             adapter_entry["skills_link"] = skills_link
-            adapter_entry["skills_link_pre_existed"] = False
+            adapter_entry["skills_link_pre_existed"] = skills_link_pre_existed
         doc["adapters"][name] = adapter_entry
 
     state_mod.save(target_root, doc)

--- a/harness_manager/doctor.py
+++ b/harness_manager/doctor.py
@@ -8,6 +8,7 @@ First run on a pre-v0.9.0 project (no install.json) detects adapters
 from filesystem signals and ASKS before synthesizing — never silently
 writes. Codex's UX framing: doctor must not mutate without consent.
 """
+import os
 import shutil
 import sys
 from pathlib import Path
@@ -49,7 +50,17 @@ def audit(target_root: Path | str, log: Callable[[str], None] | None = None) -> 
     if log is None:
         log = print
 
-    target_root = Path(target_root).resolve()
+    # os.path.abspath (not Path.resolve) is deliberate: it normalizes
+    # `.`/`..` and prepends cwd for relative paths but does NOT canon-
+    # icalize symlinks. The legacy bash installer used the logical
+    # path (`cd "$TARGET" && pwd`) to derive the openclaw agent name
+    # via cksum, and post_install.py does the same. If doctor resolves
+    # symlinks here, a pre-v0.9 openclaw install under e.g. a symlinked
+    # `~/src/app` workspace gets a DIFFERENT hashed agent name during
+    # synthesis than the bash installer registered — doctor then can't
+    # recover the agent from ~/.openclaw/openclaw.json, and a later
+    # remove has no agent_name to unregister, orphaning the entry.
+    target_root = Path(os.path.abspath(str(target_root)))
     doc = state_mod.load(target_root)
 
     if doc is None:
@@ -88,6 +99,18 @@ def _audit_adapter(
     for f in entry.get("files_written", []) + entry.get("files_overwritten", []):
         if not (target_root / f).exists():
             missing.append(f)
+    # Also check file_results for paths that install recorded as
+    # skipped_existing (merge_policy: skip_if_exists, file pre-existed)
+    # or left_alone (merge_or_alert, file already referenced .agent/).
+    # These aren't in files_written/files_overwritten but are still part
+    # of the adapter's wiring — without this check, deleting e.g. run.py
+    # after installing standalone-python leaves the adapter visibly
+    # green in doctor when it's actually broken.
+    for r in entry.get("file_results", []):
+        if r.get("result") in ("skipped_existing", "left_alone"):
+            dst = r.get("dst")
+            if dst and not (target_root / dst).exists() and dst not in missing:
+                missing.append(dst)
     if missing:
         lines.append(f"missing files: {', '.join(missing)}")
         return RED, lines
@@ -130,6 +153,25 @@ def _audit_adapter(
         if dst.is_symlink() and not dst.exists():
             lines.append(f"skills_link {sl['dst']} dangles")
             return RED, lines
+        # Verify the link (or rsynced dir) still resolves to the manifest
+        # target. A user who repoints `.agents/skills` / `.pi/skills` to
+        # a different directory would otherwise get a green doctor even
+        # though the adapter is no longer reading the project's
+        # .agent/skills tree.
+        expected_target = sl.get("target")
+        if expected_target and dst.is_symlink():
+            try:
+                resolved = dst.resolve()
+                expected_abs = (target_root / expected_target).resolve()
+                if resolved != expected_abs:
+                    lines.append(
+                        f"skills_link {sl['dst']} points to {resolved} "
+                        f"(expected {expected_abs})"
+                    )
+                    status_overall = RED
+            except OSError as e:
+                lines.append(f"skills_link {sl['dst']} unreadable: {e}")
+                status_overall = RED
 
     # Check post_install state. Only verify external state for actions that
     # actually succeeded — if registration was skipped at install time
@@ -147,11 +189,20 @@ def _audit_adapter(
                 if check_status == "ok":
                     lines.append(f"openclaw agent '{agent}' registered")
                 elif check_status == "binary_missing":
+                    # "binary_missing" is a historical misnomer here —
+                    # _check_openclaw_agent reads ~/.openclaw/openclaw.json
+                    # directly rather than calling the binary, so this
+                    # status means the CONFIG FILE is absent. For a
+                    # registration that was previously ok, an absent
+                    # config file means every registered agent is gone
+                    # — the adapter is objectively broken, not merely
+                    # unverifiable. RED, not YELLOW.
                     lines.append(
-                        f"openclaw agent '{agent}' was registered, but openclaw "
-                        f"binary not on PATH now — can't verify"
+                        f"openclaw agent '{agent}' was registered, but "
+                        f"~/.openclaw/openclaw.json no longer exists — "
+                        f"registration lost"
                     )
-                    status_overall = max(status_overall, YELLOW, key=_status_rank)
+                    status_overall = RED
                 elif check_status == "missing":
                     lines.append(
                         f"openclaw agent '{agent}' was registered, but no longer "
@@ -233,7 +284,19 @@ def _audit_pre_v090(target_root: Path, log: Callable[[str], None]) -> int:
 
     Codex UX rule: never silently mutate. Show user what we found, ask Y/N,
     write only on confirmation. On N or non-tty, exit 0 with no write.
+
+    Synthesis requires the distinctive brain layout (.agent/memory/,
+    skills/, protocols/) to exist. Without this gate, a random repo
+    that happens to contain a common filename like `run.py` or
+    `AGENTS.md` would prompt the user and on Enter write a bogus
+    install.json for adapters that were never installed.
     """
+    if not state_mod.brain_present(target_root):
+        log(f"no install.json found at {target_root / '.agent/install.json'}")
+        log(f"no agentic-stack brain found at {target_root / '.agent'} either.")
+        log("nothing to audit. install an adapter with: ./install.sh <adapter-name>")
+        return 0
+
     detected: list[tuple[str, str]] = []  # (name, signal_strength_summary)
     for name, signals in DETECT_SIGNALS.items():
         present = [(f, strength) for f, strength in signals
@@ -246,7 +309,7 @@ def _audit_pre_v090(target_root: Path, log: Callable[[str], None]) -> int:
 
     if not detected:
         log(f"no install.json found at {target_root / '.agent/install.json'}")
-        log("no adapter signals detected either. nothing to audit.")
+        log("brain is present but no adapter signals detected.")
         log("install an adapter with: ./install.sh <adapter-name>")
         return 0
 

--- a/harness_manager/install.py
+++ b/harness_manager/install.py
@@ -231,8 +231,26 @@ def install(
             files_alerted.append(entry["dst"])
         file_results.append({"dst": entry["dst"], "result": result})
 
-    # 3. Skills link.
+    # 3. Skills link. Track whether the destination pre-existed before
+    #    install touched it — if so, remove must NOT delete it (codex P1:
+    #    `./install.sh remove codex` would otherwise wipe a user-owned
+    #    `.agents/skills/` that the installer adopted, not created).
+    skills_link_pre_existed = False
     if "skills_link" in manifest:
+        skills_dst = target_root / manifest["skills_link"]["dst"]
+        skills_link_pre_existed = (
+            skills_dst.exists() or skills_dst.is_symlink()
+        )
+        # Preserve prior install.json's pre-existence flag across re-installs:
+        # if WE created the link first time, the second install detecting it
+        # exists doesn't make it user-owned now. (Same logic shape as the
+        # files_written ownership preservation above.)
+        prior_skills_pre_existed = (prior_entry.get("skills_link_pre_existed", False))
+        if entry_was_owned_in_prior_install := (
+            "skills_link" in prior_entry
+            and not prior_skills_pre_existed
+        ):
+            skills_link_pre_existed = False
         _resolve_skills_link(target_root, manifest["skills_link"], log)
 
     # 4. Post-install actions.
@@ -272,6 +290,7 @@ def install(
     }
     if "skills_link" in manifest:
         entry["skills_link"] = manifest["skills_link"]
+        entry["skills_link_pre_existed"] = skills_link_pre_existed
     if manifest.get("brain_root_primitive"):
         entry["brain_root_primitive"] = manifest["brain_root_primitive"]
 

--- a/harness_manager/install.py
+++ b/harness_manager/install.py
@@ -181,6 +181,16 @@ def install(
     files_alerted: list[str] = []        # merge_or_alert that left existing alone — needs user action
     file_results: list[dict] = []
 
+    # On reinstall, look up the previous install.json entry for this adapter
+    # so we can preserve installer-owned classification across re-runs. A
+    # naive "if it exists now, it pre-existed" misclassifies our own
+    # installer-created files as user-owned the second time around — then
+    # `remove` would silently leave behind CLAUDE.md / .cursor/rules/*.mdc
+    # because it stopped seeing them as ours.
+    prior_doc = state_mod.load(target_root) or {}
+    prior_entry = (prior_doc.get("adapters") or {}).get(adapter_name) or {}
+    prior_owned = set(prior_entry.get("files_written") or [])
+
     # 2. Process file entries.
     for entry in manifest["files"]:
         from_stack = entry.get("from_stack", False)
@@ -209,7 +219,14 @@ def install(
         if result == "written_new":
             files_written.append(entry["dst"])
         elif result == "written_overwrite":
-            files_overwritten.append(entry["dst"])
+            # If we created this file in a previous install (recorded in the
+            # prior install.json's files_written), this is a re-install
+            # overwriting our OWN file, not a user file. Keep it classified
+            # as installer-owned so remove will clean it up.
+            if entry["dst"] in prior_owned:
+                files_written.append(entry["dst"])
+            else:
+                files_overwritten.append(entry["dst"])
         elif result == "merge_alert":
             files_alerted.append(entry["dst"])
         file_results.append({"dst": entry["dst"], "result": result})

--- a/harness_manager/install.py
+++ b/harness_manager/install.py
@@ -1,0 +1,263 @@
+"""Manifest-driven adapter installation.
+
+Reads adapters/<name>/adapter.json, applies its files + skills_link +
+post_install actions to a target project, records what was done in
+.agent/install.json. install.sh and install.ps1 dispatch into here.
+"""
+import shutil
+import sys
+from pathlib import Path
+from typing import Callable, Iterable
+
+from . import post_install as post_install_mod
+from . import schema as schema_mod
+from . import state as state_mod
+from . import __version__
+
+
+# ---- merge policies ---------------------------------------------------
+
+def _apply_file(
+    src_content: bytes,
+    src_text_for_alert: str,
+    dst_path: Path,
+    merge_policy: str,
+    log: Callable[[str], None],
+) -> str:
+    """Write src_content to dst_path according to merge_policy.
+
+    Returns: 'written' | 'skipped_existing' | 'merge_alert' | 'left_alone'
+    """
+    dst_path.parent.mkdir(parents=True, exist_ok=True)
+    if not dst_path.exists():
+        dst_path.write_bytes(src_content)
+        log(f"  + {_short(dst_path)}")
+        return "written"
+
+    if merge_policy == "overwrite":
+        dst_path.write_bytes(src_content)
+        log(f"  ~ {_short(dst_path)} (overwritten)")
+        return "written"
+
+    if merge_policy == "skip_if_exists":
+        log(f"  ~ {_short(dst_path)} already exists — skipping")
+        return "skipped_existing"
+
+    if merge_policy == "merge_or_alert":
+        # If the existing file already references .agent/, leave alone — it's
+        # already wired (could be from a prior install or another adapter).
+        try:
+            existing = dst_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            existing = ""
+        if ".agent/" in existing:
+            log(f"  ~ {_short(dst_path)} already references .agent/ — leaving alone")
+            return "left_alone"
+        log(f"  ! {_short(dst_path)} exists but does not reference .agent/; not overwriting.")
+        log("    merge this block into your file to wire the brain:")
+        log("    ---8<---")
+        for line in src_text_for_alert.splitlines():
+            log(f"    {line}")
+        log("    --->8---")
+        return "merge_alert"
+
+    raise ValueError(f"unknown merge_policy '{merge_policy}'")
+
+
+# ---- skills_link ------------------------------------------------------
+
+def _resolve_skills_link(
+    target_root: Path,
+    spec: dict,
+    log: Callable[[str], None],
+) -> str:
+    """Symlink dst -> target. Fall back to rsync_with_delete if symlink fails.
+
+    Mirrors the logic from install.sh master after PR #19 fixed the
+    silent-orphan bug (-L/-d explicit detection before ln -sfn).
+    """
+    target_link = target_root / spec["target"]  # e.g. .agent/skills
+    dst = target_root / spec["dst"]              # e.g. .pi/skills
+    fallback = spec.get("fallback", "rsync_with_delete")
+
+    if not target_link.is_dir():
+        raise FileNotFoundError(
+            f"skills_link target {target_link} does not exist; "
+            f"cannot create symlink/mirror"
+        )
+
+    # Resolve target to absolute for the symlink itself.
+    target_abs = target_link.resolve()
+
+    dst.parent.mkdir(parents=True, exist_ok=True)
+
+    # Case 1: dst is an existing symlink → repoint (cheap)
+    if dst.is_symlink():
+        dst.unlink()
+        try:
+            dst.symlink_to(target_abs)
+            log(f"  + {_short(dst)} -> {target_abs}")
+            return "symlinked"
+        except OSError:
+            pass  # fall through to copy
+
+    # Case 2: dst is a real directory → sync with delete-orphans
+    if dst.is_dir() and not dst.is_symlink():
+        if fallback == "rsync_with_delete" and shutil.which("rsync"):
+            import subprocess
+            subprocess.run(
+                ["rsync", "-a", "--delete", str(target_abs) + "/", str(dst) + "/"],
+                check=True,
+            )
+            log(f"  ~ synced {_short(dst)} (rsync --delete)")
+            return "rsynced"
+        # rm -rf + cp -r
+        shutil.rmtree(dst)
+        shutil.copytree(target_abs, dst)
+        log(f"  ~ replaced {_short(dst)} with current {_short(target_link)}")
+        return "rsynced"
+
+    # Case 3: dst doesn't exist → try symlink, fall back to copy
+    try:
+        dst.symlink_to(target_abs)
+        log(f"  + {_short(dst)} -> {target_abs}")
+        return "symlinked"
+    except OSError:
+        shutil.copytree(target_abs, dst)
+        log(f"  + {_short(dst)} (copy; symlink not supported here)")
+        return "copied"
+
+
+# ---- variable substitution -------------------------------------------
+
+def _substitute(content: bytes, manifest: dict, target_root: Path) -> bytes:
+    """Replace {{BRAIN_ROOT}} etc. in file content. Bytes in, bytes out."""
+    primitive = manifest.get("brain_root_primitive")
+    if primitive is None:
+        return content
+    text = content.decode("utf-8")
+    text = text.replace("{{BRAIN_ROOT}}", primitive)
+    text = text.replace("{{ABS_TARGET}}", str(target_root.resolve()))
+    return text.encode("utf-8")
+
+
+# ---- main install ----------------------------------------------------
+
+def install(
+    manifest: dict,
+    target_root: Path | str,
+    adapter_dir: Path | str,
+    stack_root: Path | str,
+    log: Callable[[str], None] | None = None,
+) -> dict:
+    """Apply one adapter's manifest to target_root. Returns install.json entry."""
+    if log is None:
+        log = print
+
+    target_root = Path(target_root)
+    adapter_dir = Path(adapter_dir)
+    stack_root = Path(stack_root)
+    adapter_name = manifest["name"]
+
+    log(f"installing '{adapter_name}' into {target_root}")
+
+    # 1. Drop .agent/ brain if not present (top-level concern, before any
+    #    file entry; some entries depend on .agent/ existing, e.g. pi's
+    #    skills_link target = .agent/skills).
+    target_agent = target_root / ".agent"
+    if not target_agent.exists():
+        shutil.copytree(stack_root / ".agent", target_agent)
+        log("  + .agent/ (portable brain)")
+
+    files_written: list[str] = []
+    file_results: list[dict] = []
+
+    # 2. Process file entries.
+    for entry in manifest["files"]:
+        from_stack = entry.get("from_stack", False)
+        src_root = stack_root if from_stack else adapter_dir
+        src_path = src_root / entry["src"]
+        if not src_path.is_file():
+            raise FileNotFoundError(
+                f"adapter '{adapter_name}' file entry: {src_path} does not exist"
+            )
+        content = src_path.read_bytes()
+        if entry.get("substitute", False):
+            content = _substitute(content, manifest, target_root)
+        merge_policy = entry.get("merge_policy", "overwrite")
+        # For merge_or_alert we need text for the snippet output.
+        try:
+            src_text = content.decode("utf-8")
+        except UnicodeDecodeError:
+            src_text = "<binary file — see adapter source for content>"
+        result = _apply_file(
+            src_content=content,
+            src_text_for_alert=src_text,
+            dst_path=target_root / entry["dst"],
+            merge_policy=merge_policy,
+            log=log,
+        )
+        if result == "written":
+            files_written.append(entry["dst"])
+        file_results.append({"dst": entry["dst"], "result": result})
+
+    # 3. Skills link.
+    if "skills_link" in manifest:
+        _resolve_skills_link(target_root, manifest["skills_link"], log)
+
+    # 4. Post-install actions.
+    post_install_results: list[dict] = []
+    for action_name in manifest.get("post_install", []):
+        log(f"  → post-install: {action_name}")
+        result = post_install_mod.run(action_name, target_root)
+        post_install_results.append(result)
+        # User-facing summary line
+        status = result.get("status", "?")
+        if status == "ok":
+            log(f"    ✓ {action_name} ok")
+        elif status == "already_exists":
+            log(f"    ✓ {action_name} idempotent (already present)")
+        elif status == "binary_missing":
+            log(f"    ! {action_name}: binary missing")
+            hint = result.get("fallback_hint")
+            if hint:
+                log(f"      {hint}")
+        else:
+            log(f"    ! {action_name}: {status}")
+            err = result.get("stderr", "")
+            if err:
+                log(f"      {err.splitlines()[0] if err else ''}")
+            hint = result.get("fallback_hint")
+            if hint:
+                log(f"      fallback: {hint}")
+
+    # 5. Build the install.json entry.
+    entry = {
+        "installed_at": _iso_now(),
+        "files_written": files_written,
+        "file_results": file_results,
+        "post_install_results": post_install_results,
+    }
+    if "skills_link" in manifest:
+        entry["skills_link"] = manifest["skills_link"]
+    if manifest.get("brain_root_primitive"):
+        entry["brain_root_primitive"] = manifest["brain_root_primitive"]
+
+    state_mod.upsert_adapter(target_root, adapter_name, entry, __version__)
+    log("done.")
+    return entry
+
+
+# ---- helpers ---------------------------------------------------------
+
+def _short(p: Path) -> str:
+    """Shortened path for log lines: relative to cwd if possible."""
+    try:
+        return str(p.relative_to(Path.cwd()))
+    except ValueError:
+        return str(p)
+
+
+def _iso_now() -> str:
+    import datetime as _dt
+    return _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/harness_manager/install.py
+++ b/harness_manager/install.py
@@ -26,18 +26,25 @@ def _apply_file(
 ) -> str:
     """Write src_content to dst_path according to merge_policy.
 
-    Returns: 'written' | 'skipped_existing' | 'merge_alert' | 'left_alone'
+    Returns one of:
+      'written_new'        — created the file fresh; safe for `remove` to delete
+      'written_overwrite'  — overwrote a pre-existing user file; remove must NOT delete it
+      'skipped_existing'   — left an existing file alone (skip_if_exists policy)
+      'left_alone'         — merge_or_alert: existing already references .agent/, no action needed
+      'merge_alert'        — merge_or_alert: existing did NOT reference .agent/; user must merge manually
     """
     dst_path.parent.mkdir(parents=True, exist_ok=True)
-    if not dst_path.exists():
+    pre_existed = dst_path.exists()
+
+    if not pre_existed:
         dst_path.write_bytes(src_content)
         log(f"  + {_short(dst_path)}")
-        return "written"
+        return "written_new"
 
     if merge_policy == "overwrite":
         dst_path.write_bytes(src_content)
-        log(f"  ~ {_short(dst_path)} (overwritten)")
-        return "written"
+        log(f"  ~ {_short(dst_path)} (overwritten — preserved on remove)")
+        return "written_overwrite"
 
     if merge_policy == "skip_if_exists":
         log(f"  ~ {_short(dst_path)} already exists — skipping")
@@ -169,7 +176,9 @@ def install(
         shutil.copytree(stack_root / ".agent", target_agent)
         log("  + .agent/ (portable brain)")
 
-    files_written: list[str] = []
+    files_written: list[str] = []        # we created — safe for remove to delete
+    files_overwritten: list[str] = []    # we modified but file pre-existed — DO NOT delete on remove
+    files_alerted: list[str] = []        # merge_or_alert that left existing alone — needs user action
     file_results: list[dict] = []
 
     # 2. Process file entries.
@@ -197,8 +206,12 @@ def install(
             merge_policy=merge_policy,
             log=log,
         )
-        if result == "written":
+        if result == "written_new":
             files_written.append(entry["dst"])
+        elif result == "written_overwrite":
+            files_overwritten.append(entry["dst"])
+        elif result == "merge_alert":
+            files_alerted.append(entry["dst"])
         file_results.append({"dst": entry["dst"], "result": result})
 
     # 3. Skills link.
@@ -234,7 +247,9 @@ def install(
     # 5. Build the install.json entry.
     entry = {
         "installed_at": _iso_now(),
-        "files_written": files_written,
+        "files_written": files_written,            # cleanup-safe (remove deletes these)
+        "files_overwritten": files_overwritten,    # pre-existed user content (remove leaves alone)
+        "files_alerted": files_alerted,            # merge_alert: needs manual merge by user
         "file_results": file_results,
         "post_install_results": post_install_results,
     }
@@ -244,6 +259,9 @@ def install(
         entry["brain_root_primitive"] = manifest["brain_root_primitive"]
 
     state_mod.upsert_adapter(target_root, adapter_name, entry, __version__)
+    if files_alerted:
+        log(f"  ! adapter installed BUT requires manual merge into: {', '.join(files_alerted)}")
+        log("    `./install.sh doctor` will flag this until you merge the snippet above.")
     log("done.")
     return entry
 

--- a/harness_manager/install.py
+++ b/harness_manager/install.py
@@ -124,7 +124,19 @@ def _resolve_skills_link(
         log(f"  ~ replaced {_short(dst)} with current {_short(target_link)}")
         return "rsynced"
 
-    # Case 3: dst doesn't exist → try symlink, fall back to copy
+    # Case 3: dst exists as a regular file (not symlink, not dir).
+    # Rare but possible — a user created a literal file at the skills
+    # path. Symlink_to and copytree both fail with FileExistsError in
+    # this state. Bail loudly so the user knows to resolve it; silently
+    # clobbering could delete content we can't prove we created.
+    if dst.exists() and not dst.is_dir() and not dst.is_symlink():
+        raise FileExistsError(
+            f"skills_link destination {dst} exists as a regular file, "
+            f"not a directory or symlink. move or delete it first and "
+            f"re-run install."
+        )
+
+    # Case 4: dst doesn't exist → try symlink, fall back to copy
     try:
         dst.symlink_to(target_abs)
         log(f"  + {_short(dst)} -> {target_abs}")
@@ -190,6 +202,15 @@ def install(
     prior_doc = state_mod.load(target_root) or {}
     prior_entry = (prior_doc.get("adapters") or {}).get(adapter_name) or {}
     prior_owned = set(prior_entry.get("files_written") or [])
+    # Intentionally NOT promoting synthesized files_overwritten or
+    # files_alerted into prior_owned. Reinstalling after pre-v0.9
+    # migration does not recover whether a file originally pre-existed
+    # the legacy install; even an overwrite-policy file like CLAUDE.md
+    # could have had user content that the old installer clobbered,
+    # and we'd have no way to know. Conservative tradeoff: installer-
+    # created files from pre-v0.9 may linger on disk after `remove` if
+    # the user migrated via doctor. Users who want strict ownership
+    # tracking should install via v0.9+ from the start.
 
     # 2. Process file entries.
     for entry in manifest["files"]:
@@ -227,6 +248,17 @@ def install(
                 files_written.append(entry["dst"])
             else:
                 files_overwritten.append(entry["dst"])
+        elif result in ("skipped_existing", "left_alone"):
+            # File wasn't touched on this pass. But if we created it in a
+            # prior install, keep it in files_written so `remove` can
+            # still clean it up later — otherwise any reinstall of an
+            # adapter using skip_if_exists / merge_or_alert silently
+            # drops the file from ownership tracking on the second pass
+            # (e.g. run.py for standalone-python, AGENTS.md for pi).
+            # Not in prior_owned → file pre-existed before we ever
+            # touched this project; it's user-owned and stays untracked.
+            if entry["dst"] in prior_owned:
+                files_written.append(entry["dst"])
         elif result == "merge_alert":
             files_alerted.append(entry["dst"])
         file_results.append({"dst": entry["dst"], "result": result})
@@ -246,6 +278,13 @@ def install(
         # exists doesn't make it user-owned now. (Same logic shape as the
         # files_written ownership preservation above.)
         prior_skills_pre_existed = (prior_entry.get("skills_link_pre_existed", False))
+        # Intentionally NOT flipping pre_existed on synthesized entries.
+        # Doctor conservatively marks `.agents/skills` or `.pi/skills`
+        # as pre-existing because we can't know if the user's own
+        # skills dir was there before the legacy install. Flipping on
+        # reinstall would let remove delete a directory that predated
+        # us, potentially containing user content. Same conservative
+        # tradeoff as the files_overwritten case above.
         if entry_was_owned_in_prior_install := (
             "skills_link" in prior_entry
             and not prior_skills_pre_existed

--- a/harness_manager/manage_tui.py
+++ b/harness_manager/manage_tui.py
@@ -1,0 +1,215 @@
+"""Persistent TUI menu loop for managing installed adapters.
+
+Entry point: `./install.sh manage`. Re-entrant — the user picks an
+action, the action runs (with its own prompts as needed), then we
+return to the menu. Exits cleanly on `q`, `Exit` menu pick, or two
+consecutive Ctrl-C presses.
+
+Reuses onboard_widgets.ask_select / ask_multiselect / ask_confirm
+for consistency with the existing wizard. No new UI primitives
+beyond the multi-select widget added at the same time.
+"""
+import os
+import shutil
+import signal
+import sys
+from pathlib import Path
+
+# onboard_widgets and onboard_ui live at repo root, not under
+# harness_manager/. install.sh prepends repo root to PYTHONPATH so this
+# import works.
+import onboard_widgets as widgets  # noqa: E402
+from onboard_ui import (  # noqa: E402
+    R, B, GREEN, ORANGE, MUTED, WHITE, BLUE, PURPLE, BAR,
+)
+
+from . import doctor as doctor_mod
+from . import install as install_mod
+from . import remove as remove_mod
+from . import schema as schema_mod
+from . import state as state_mod
+from . import status as status_mod
+from . import __version__
+
+
+# ---- header pane -----------------------------------------------------
+
+def _render_header(target_root: Path) -> None:
+    """One-screen project + brain + adapter summary above the menu prompt."""
+    doc = state_mod.load(target_root) or {}
+    adapters = doc.get("adapters", {}) or {}
+
+    print()
+    print(f"{PURPLE}{B}╭─ agentic-stack — manage{R}")
+    print(f"{BAR}  project:  {WHITE}{target_root}{R}")
+    print(f"{BAR}  brain:    .agent/  {MUTED}({_brain_summary(target_root)}){R}")
+    print(f"{BAR}  version:  agentic-stack {doc.get('agentic_stack_version', __version__)}")
+    print(f"{BAR}")
+    if not adapters:
+        print(f"{BAR}  {MUTED}no adapters installed yet{R}")
+    else:
+        print(f"{BAR}  installed adapters ({len(adapters)}):")
+        # Quick non-mutating audit of each adapter so we can show colour
+        # status alongside name.
+        for name in sorted(adapters):
+            entry = adapters[name]
+            status, _ = doctor_mod._audit_adapter(target_root, name, entry)
+            glyph_color = {"green": GREEN, "yellow": ORANGE, "red": MUTED}.get(status, MUTED)
+            glyph = {"green": "✓", "yellow": "⚠", "red": "✗"}.get(status, "?")
+            print(f"{BAR}    {glyph_color}{glyph}{R} {WHITE}{name:18s}{R}  {glyph_color}{status}{R}")
+    print(f"{BAR}")
+
+
+def _brain_summary(target_root: Path) -> str:
+    return status_mod._brain_summary(target_root)
+
+
+# ---- menu actions ----------------------------------------------------
+
+def _action_add(target_root: Path, stack_root: Path) -> None:
+    """Multi-select adapters NOT already installed; install each."""
+    doc = state_mod.load(target_root) or {}
+    installed = set(doc.get("adapters") or {})
+    available = sorted(
+        n for n, _ in schema_mod.discover_all(stack_root)
+        if n not in installed
+    )
+    if not available:
+        print(f"  {MUTED}all available adapters are already installed.{R}")
+        return
+    chosen = widgets.ask_multiselect(
+        "select adapters to add (q to cancel)",
+        available,
+    )
+    if not chosen:
+        print(f"  {MUTED}no adapters selected; nothing changed.{R}")
+        return
+    for name in chosen:
+        manifest_path = stack_root / "adapters" / name / "adapter.json"
+        manifest = schema_mod.validate(manifest_path)
+        install_mod.install(
+            manifest=manifest,
+            target_root=target_root,
+            adapter_dir=stack_root / "adapters" / name,
+            stack_root=stack_root,
+        )
+
+
+def _action_remove(target_root: Path) -> None:
+    """Multi-select adapters from installed; remove each (with per-adapter confirm)."""
+    doc = state_mod.load(target_root) or {}
+    installed = sorted((doc.get("adapters") or {}).keys())
+    if not installed:
+        print(f"  {MUTED}nothing to remove — no adapters installed.{R}")
+        return
+    chosen = widgets.ask_multiselect(
+        "select adapters to remove (q to cancel)",
+        installed,
+    )
+    if not chosen:
+        print(f"  {MUTED}no adapters selected; nothing changed.{R}")
+        return
+    for name in chosen:
+        # remove() prompts for its own per-adapter [y/N] confirm with the
+        # destruction file list. That's the right place to ask, not the
+        # menu — keeps the destructive prompt next to the destructive op.
+        remove_mod.remove(target_root, name, yes=False)
+
+
+def _action_doctor(target_root: Path) -> None:
+    """Run audit. Same exit-code semantics as `./install.sh doctor`."""
+    rc = doctor_mod.audit(target_root)
+    if rc != 0:
+        print(f"  {ORANGE}doctor exited non-zero — see above.{R}")
+
+
+def _action_status(target_root: Path) -> None:
+    """Print the full status view (header pane only shows summary)."""
+    status_mod.show(target_root)
+
+
+def _action_reconfigure(target_root: Path, stack_root: Path) -> None:
+    """Re-run onboard.py PREFERENCES.md flow."""
+    onboard = stack_root / "onboard.py"
+    if not onboard.is_file():
+        print(f"  {MUTED}onboard.py not found at {onboard}{R}")
+        return
+    import subprocess
+    subprocess.run(
+        [sys.executable, str(onboard), str(target_root), "--reconfigure"],
+        check=False,
+    )
+
+
+# ---- main menu loop --------------------------------------------------
+
+# Ordered: user-facing labels (left) → internal action tag (right).
+_MENU = [
+    ("Add an adapter",       "add"),
+    ("Remove an adapter",    "remove"),
+    ("Run doctor (audit)",   "doctor"),
+    ("Show status",          "status"),
+    ("Reconfigure preferences", "reconfigure"),
+    ("Exit",                 "exit"),
+]
+
+
+def _sigint_handler_factory():
+    """SIGINT handler with two-Ctrl-C-to-exit semantics.
+
+    First Ctrl-C inside the menu: print a hint, return to menu (handled
+    by the loop catching KeyboardInterrupt). Two consecutive Ctrl-Cs
+    within ~1 second: actually exit. Reset the counter on every
+    successful menu iteration.
+    """
+    state = {"last": 0.0}
+    def _handler(signum, frame):
+        import time
+        now = time.time()
+        if now - state["last"] < 1.0:
+            print()
+            print(f"  {MUTED}two ctrl-c — exiting.{R}")
+            sys.exit(130)
+        state["last"] = now
+        # Re-raise as KeyboardInterrupt so the loop body can catch it.
+        raise KeyboardInterrupt
+    return _handler
+
+
+def run(target_root: Path | str, stack_root: Path | str) -> int:
+    """Enter the menu loop. Returns exit code on quit."""
+    target_root = Path(target_root).resolve()
+    stack_root = Path(stack_root)
+
+    # Install our SIGINT handler.
+    signal.signal(signal.SIGINT, _sigint_handler_factory())
+
+    while True:
+        try:
+            _render_header(target_root)
+            choice_label = widgets.ask_select(
+                "what do you want to do?",
+                [label for label, _ in _MENU],
+            )
+            tag = next(t for label, t in _MENU if label == choice_label)
+        except KeyboardInterrupt:
+            print()
+            print(f"  {MUTED}ctrl-c again to exit, or pick an action.{R}")
+            continue
+
+        if tag == "exit":
+            print(f"  {MUTED}bye.{R}")
+            return 0
+
+        try:
+            if   tag == "add":         _action_add(target_root, stack_root)
+            elif tag == "remove":      _action_remove(target_root)
+            elif tag == "doctor":      _action_doctor(target_root)
+            elif tag == "status":      _action_status(target_root)
+            elif tag == "reconfigure": _action_reconfigure(target_root, stack_root)
+        except KeyboardInterrupt:
+            print()
+            print(f"  {MUTED}action cancelled.{R}")
+        except Exception as e:  # pragma: no cover — last-resort safety
+            print(f"  {ORANGE}error: {type(e).__name__}: {e}{R}")
+        # Loop back to header + menu.

--- a/harness_manager/manage_tui.py
+++ b/harness_manager/manage_tui.py
@@ -67,8 +67,27 @@ def _brain_summary(target_root: Path) -> str:
 # ---- menu actions ----------------------------------------------------
 
 def _action_add(target_root: Path, stack_root: Path) -> None:
-    """Multi-select adapters NOT already installed; install each."""
-    doc = state_mod.load(target_root) or {}
+    """Multi-select adapters NOT already installed; install each.
+
+    Refuses on pre-v0.9 projects (no install.json yet) when adapter
+    signals are already on disk — same migration gate cmd_add uses in
+    cli.py. Without this, the TUI would create a fresh install.json
+    tracking only the newly-added adapters and orphan every pre-v0.9
+    install, making them invisible to status/doctor/remove even though
+    their files are still on disk.
+    """
+    doc = state_mod.load(target_root)
+    was_fresh = doc is None
+    if doc is None:
+        detected = state_mod.legacy_unregistered_adapters(target_root)
+        if detected:
+            print(f"  {ORANGE}pre-v0.9 project detected.{R}")
+            print(f"  .agent/ exists but install.json does not yet.")
+            print(f"  adapters on disk: {detected}")
+            print(f"  {MUTED}pick 'Run doctor (audit)' from this menu "
+                  f"first to register them safely.{R}")
+            return
+        doc = {}
     installed = set(doc.get("adapters") or {})
     available = sorted(
         n for n, _ in schema_mod.discover_all(stack_root)
@@ -93,6 +112,18 @@ def _action_add(target_root: Path, stack_root: Path) -> None:
             adapter_dir=stack_root / "adapters" / name,
             stack_root=stack_root,
         )
+    # First-time install via the manage TUI: run onboard.py so the
+    # PREFERENCES step happens, matching what ./install.sh <adapter>
+    # and the bare wizard do. Skipping this would leave TUI-first
+    # installs with an uninitialized PREFERENCES.md.
+    if was_fresh:
+        onboard = stack_root / "onboard.py"
+        if onboard.is_file():
+            import subprocess
+            subprocess.run(
+                [sys.executable, str(onboard), str(target_root)],
+                check=False,
+            )
 
 
 def _action_remove(target_root: Path) -> None:
@@ -178,7 +209,15 @@ def _sigint_handler_factory():
 
 def run(target_root: Path | str, stack_root: Path | str) -> int:
     """Enter the menu loop. Returns exit code on quit."""
-    target_root = Path(target_root).resolve()
+    # os.path.abspath (not Path.resolve) deliberately: normalizes `.`
+    # and `..` but does NOT canonicalize symlinks. The openclaw agent
+    # name is derived from this path via cksum in post_install.py, so
+    # resolving symlinks here would produce a different hash than
+    # ./install.sh add openclaw (which doesn't resolve) — installs via
+    # the TUI would register a DIFFERENT agent for symlinked
+    # workspaces, creating duplicate entries in ~/.openclaw/openclaw.json.
+    # Same logical-path discipline doctor.audit uses.
+    target_root = Path(os.path.abspath(str(target_root)))
     stack_root = Path(stack_root)
 
     # Install our SIGINT handler.

--- a/harness_manager/post_install.py
+++ b/harness_manager/post_install.py
@@ -8,10 +8,19 @@ This is deliberately not a plugin DSL or arbitrary command runner. The
 codex review of the v1.0 vision plan flagged generalized run_command as
 DSL creep; named built-ins are the constrained alternative.
 """
+import re
 import shutil
+import string
 import subprocess
 from pathlib import Path
 from typing import Callable
+
+# ASCII-only allowed set for openclaw agent name basenames. Mirrors
+# `tr -c 'A-Za-z0-9._-'` from the legacy bash. str.isalnum() is not safe
+# here because it accepts non-ASCII letters — `café`.isalnum() is True
+# but bash `tr` would have replaced ç with `-`. Without this exact match,
+# upgrade installs would generate different agent ids and create duplicates.
+_OPENCLAW_AGENT_NAME_ALLOWED = set(string.ascii_letters + string.digits + "._-")
 
 
 def _abs_target(target_root: Path | str) -> Path:
@@ -66,8 +75,15 @@ def _openclaw_agent_name(target_root: Path | str) -> str:
     """
     abs_target = _abs_target(target_root)
     bn_raw = abs_target.name.lower()
-    safe = "".join(c if (c.isalnum() or c in "._-") else "-" for c in bn_raw)
-    safe = safe.strip("-").replace("--", "-") or "project"
+    # ASCII-only sanitizer: replace any char outside [a-z0-9._-] with `-`.
+    # Mirrors `tr -c 'A-Za-z0-9._-' '-'` (the lowercase pre-step makes the
+    # case range moot). Non-ASCII letters are intentionally NOT preserved.
+    safe = "".join(c if c in _OPENCLAW_AGENT_NAME_ALLOWED else "-" for c in bn_raw)
+    # Collapse runs of dashes (regex equivalent of `sed 's/-\{2,\}/-/g'`).
+    # str.replace("--", "-") is single-pass and would leave `a----b` as `a--b`.
+    safe = re.sub(r"-{2,}", "-", safe).strip("-")
+    if not safe:
+        safe = "project"
     suffix = _posix_cksum(str(abs_target).encode("utf-8")) % 1_000_000
     return f"{safe}-{suffix:06d}"
 

--- a/harness_manager/post_install.py
+++ b/harness_manager/post_install.py
@@ -146,12 +146,20 @@ def openclaw_register_workspace(target_root: Path | str, **_kwargs) -> dict:
     }
 
 
-def openclaw_unregister_workspace(target_root: Path | str, **_kwargs) -> dict:
+def openclaw_unregister_workspace(target_root: Path | str, **kwargs) -> dict:
     """Reverse of register: `openclaw agents remove <name>`. Used by `remove`.
 
     Best-effort. Returns ok if the agent was removed OR didn't exist.
+
+    IMPORTANT: prefer the agent_name passed in via kwargs (recovered from
+    install.json's post_install_results record) over recomputing it from
+    the current target_root. Otherwise a project that's been moved/renamed
+    after install will compute a different agent name (cksum of the new
+    abs path), and we'll send `openclaw agents remove <new-name>`. The
+    new name doesn't exist → openclaw says "not found" → we treat as ok
+    → the original agent stays orphaned in ~/.openclaw/openclaw.json.
     """
-    agent_name = _openclaw_agent_name(target_root)
+    agent_name = kwargs.get("agent_name") or _openclaw_agent_name(target_root)
     binary = shutil.which("openclaw")
     if not binary:
         return {

--- a/harness_manager/post_install.py
+++ b/harness_manager/post_install.py
@@ -8,6 +8,8 @@ This is deliberately not a plugin DSL or arbitrary command runner. The
 codex review of the v1.0 vision plan flagged generalized run_command as
 DSL creep; named built-ins are the constrained alternative.
 """
+import hashlib
+import platform
 import re
 import shutil
 import string
@@ -64,14 +66,19 @@ def _posix_cksum(data: bytes) -> int:
 
 
 def _openclaw_agent_name(target_root: Path | str) -> str:
-    """Match the algorithm install.sh used pre-v0.9.0 for agent-name stability.
+    """Match whichever pre-v0.9.0 algorithm was used on this platform.
 
-    install.sh (PR #15):
-      OC_PATH_CKSUM="$(printf '%s' "$OC_ABS" | cksum | awk '{print $1}')"
-      OC_AGENT_NAME="${OC_BN_SAFE}-$(printf '%06d' "$((OC_PATH_CKSUM % 1000000))")"
+    The legacy install scripts used DIFFERENT hash functions per platform:
+      install.sh:    cksum(abs_path) % 1_000_000  →  6-digit decimal suffix
+      install.ps1:   sha1(abs_path)[:6]            →  6-hex-char suffix
 
-    We replicate exactly: lowercase basename + 6-digit cksum-mod-1M suffix.
-    Same name across re-runs and across pre-v0.9.0 → v0.9.0 upgrades.
+    Switching either platform to the other algorithm on v0.9.0 upgrade
+    would compute a different agent name → register a duplicate agent →
+    `remove` targets the new one and leaves the original orphaned in
+    ~/.openclaw/openclaw.json.
+
+    So: keep cksum on POSIX, SHA1 on Windows. The agent name is naturally
+    platform-locked anyway because absolute paths differ between OSes.
     """
     abs_target = _abs_target(target_root)
     bn_raw = abs_target.name.lower()
@@ -80,12 +87,17 @@ def _openclaw_agent_name(target_root: Path | str) -> str:
     # case range moot). Non-ASCII letters are intentionally NOT preserved.
     safe = "".join(c if c in _OPENCLAW_AGENT_NAME_ALLOWED else "-" for c in bn_raw)
     # Collapse runs of dashes (regex equivalent of `sed 's/-\{2,\}/-/g'`).
-    # str.replace("--", "-") is single-pass and would leave `a----b` as `a--b`.
     safe = re.sub(r"-{2,}", "-", safe).strip("-")
     if not safe:
         safe = "project"
-    suffix = _posix_cksum(str(abs_target).encode("utf-8")) % 1_000_000
-    return f"{safe}-{suffix:06d}"
+    abs_str = str(abs_target)
+    if platform.system() == "Windows":
+        # Match the legacy install.ps1: 6-hex-char prefix of SHA1.
+        suffix = hashlib.sha1(abs_str.encode("utf-8")).hexdigest()[:6]
+    else:
+        # Match the legacy install.sh: cksum mod 1M, zero-padded 6-digit.
+        suffix = f"{_posix_cksum(abs_str.encode('utf-8')) % 1_000_000:06d}"
+    return f"{safe}-{suffix}"
 
 
 def openclaw_register_workspace(target_root: Path | str, **_kwargs) -> dict:

--- a/harness_manager/post_install.py
+++ b/harness_manager/post_install.py
@@ -8,7 +8,6 @@ This is deliberately not a plugin DSL or arbitrary command runner. The
 codex review of the v1.0 vision plan flagged generalized run_command as
 DSL creep; named built-ins are the constrained alternative.
 """
-import hashlib
 import shutil
 import subprocess
 from pathlib import Path
@@ -19,19 +18,57 @@ def _abs_target(target_root: Path | str) -> Path:
     return Path(target_root).resolve()
 
 
-def _openclaw_agent_name(target_root: Path | str) -> str:
-    """Match the algorithm install.sh uses today (PR #15) for stable names.
+# POSIX cksum CRC-32 table. Polynomial 0x04C11DB7, no inversion, length-tagged.
+# Matches `cksum(1)` output on macOS, Linux, and any POSIX system. Pre-computed
+# once at import time. Required for openclaw_register_workspace agent-name
+# stability across pre-v0.9.0 (bash) and v0.9.0+ (Python) installs — switching
+# to a different hash would create a duplicate openclaw agent on upgrade and
+# leave doctor/remove unable to find the original.
+def _build_posix_cksum_table() -> tuple[int, ...]:
+    table = []
+    for i in range(256):
+        c = i << 24
+        for _ in range(8):
+            c = ((c << 1) ^ 0x04C11DB7) & 0xFFFFFFFF if (c & 0x80000000) else (c << 1) & 0xFFFFFFFF
+        table.append(c)
+    return tuple(table)
 
-    Lowercase basename + 6-digit cksum-derived suffix. Same name across
-    re-runs of the same project, distinct across different projects.
+
+_POSIX_CKSUM_TABLE = _build_posix_cksum_table()
+
+
+def _posix_cksum(data: bytes) -> int:
+    """POSIX cksum(1) CRC-32 of `data` (no trailing newline added).
+
+    Bit-for-bit compatible with `printf '%s' "$data" | cksum | awk '{print $1}'`
+    which is what install.sh used pre-v0.9.0 to derive the openclaw agent name.
+    """
+    crc = 0
+    for b in data:
+        crc = ((crc << 8) ^ _POSIX_CKSUM_TABLE[((crc >> 24) ^ b) & 0xFF]) & 0xFFFFFFFF
+    # Append the length as the algorithm's tag.
+    length = len(data)
+    while length > 0:
+        crc = ((crc << 8) ^ _POSIX_CKSUM_TABLE[((crc >> 24) ^ (length & 0xFF)) & 0xFF]) & 0xFFFFFFFF
+        length >>= 8
+    return (~crc) & 0xFFFFFFFF
+
+
+def _openclaw_agent_name(target_root: Path | str) -> str:
+    """Match the algorithm install.sh used pre-v0.9.0 for agent-name stability.
+
+    install.sh (PR #15):
+      OC_PATH_CKSUM="$(printf '%s' "$OC_ABS" | cksum | awk '{print $1}')"
+      OC_AGENT_NAME="${OC_BN_SAFE}-$(printf '%06d' "$((OC_PATH_CKSUM % 1000000))")"
+
+    We replicate exactly: lowercase basename + 6-digit cksum-mod-1M suffix.
+    Same name across re-runs and across pre-v0.9.0 → v0.9.0 upgrades.
     """
     abs_target = _abs_target(target_root)
     bn_raw = abs_target.name.lower()
     safe = "".join(c if (c.isalnum() or c in "._-") else "-" for c in bn_raw)
     safe = safe.strip("-").replace("--", "-") or "project"
-    # cksum on macOS/Linux gives a CRC32-ish 32-bit value. Mirror that.
-    h = int(hashlib.sha1(str(abs_target).encode("utf-8")).hexdigest(), 16)
-    suffix = h % 1_000_000
+    suffix = _posix_cksum(str(abs_target).encode("utf-8")) % 1_000_000
     return f"{safe}-{suffix:06d}"
 
 

--- a/harness_manager/post_install.py
+++ b/harness_manager/post_install.py
@@ -1,0 +1,162 @@
+"""Named built-in post-install actions.
+
+Adapters declare these by name only — `post_install: ["openclaw_register_workspace"]`.
+The schema validator rejects unknown names. Adding a new action requires
+a Python function here AND a string in VALID_POST_INSTALL_ACTIONS in schema.py.
+
+This is deliberately not a plugin DSL or arbitrary command runner. The
+codex review of the v1.0 vision plan flagged generalized run_command as
+DSL creep; named built-ins are the constrained alternative.
+"""
+import hashlib
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Callable
+
+
+def _abs_target(target_root: Path | str) -> Path:
+    return Path(target_root).resolve()
+
+
+def _openclaw_agent_name(target_root: Path | str) -> str:
+    """Match the algorithm install.sh uses today (PR #15) for stable names.
+
+    Lowercase basename + 6-digit cksum-derived suffix. Same name across
+    re-runs of the same project, distinct across different projects.
+    """
+    abs_target = _abs_target(target_root)
+    bn_raw = abs_target.name.lower()
+    safe = "".join(c if (c.isalnum() or c in "._-") else "-" for c in bn_raw)
+    safe = safe.strip("-").replace("--", "-") or "project"
+    # cksum on macOS/Linux gives a CRC32-ish 32-bit value. Mirror that.
+    h = int(hashlib.sha1(str(abs_target).encode("utf-8")).hexdigest(), 16)
+    suffix = h % 1_000_000
+    return f"{safe}-{suffix:06d}"
+
+
+def openclaw_register_workspace(target_root: Path | str, **_kwargs) -> dict:
+    """Run `openclaw agents add <name> --workspace <abs>` if openclaw is on PATH.
+
+    Returns a result dict with status: ok | already_exists | failed |
+    binary_missing, plus details for the install.json record.
+    """
+    abs_target = _abs_target(target_root)
+    agent_name = _openclaw_agent_name(target_root)
+    binary = shutil.which("openclaw")
+    if not binary:
+        return {
+            "action": "openclaw_register_workspace",
+            "status": "binary_missing",
+            "agent_name": agent_name,
+            "fallback_hint": (
+                f"after installing openclaw, run: "
+                f"openclaw agents add \"{agent_name}\" --workspace \"{abs_target}\""
+            ),
+        }
+    try:
+        proc = subprocess.run(
+            [binary, "agents", "add", agent_name, "--workspace", str(abs_target)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "action": "openclaw_register_workspace",
+            "status": "failed",
+            "agent_name": agent_name,
+            "stderr": "timed out after 30s",
+        }
+    combined = (proc.stdout or "") + (proc.stderr or "")
+    if proc.returncode == 0:
+        return {
+            "action": "openclaw_register_workspace",
+            "status": "ok",
+            "agent_name": agent_name,
+        }
+    if "already exists" in combined.lower():
+        return {
+            "action": "openclaw_register_workspace",
+            "status": "already_exists",
+            "agent_name": agent_name,
+        }
+    return {
+        "action": "openclaw_register_workspace",
+        "status": "failed",
+        "agent_name": agent_name,
+        "exit_code": proc.returncode,
+        "stderr": combined.strip()[:500],
+        "fallback_hint": (
+            f"openclaw --system-prompt-file \"{abs_target}/.openclaw-system.md\""
+        ),
+    }
+
+
+def openclaw_unregister_workspace(target_root: Path | str, **_kwargs) -> dict:
+    """Reverse of register: `openclaw agents remove <name>`. Used by `remove`.
+
+    Best-effort. Returns ok if the agent was removed OR didn't exist.
+    """
+    agent_name = _openclaw_agent_name(target_root)
+    binary = shutil.which("openclaw")
+    if not binary:
+        return {
+            "action": "openclaw_unregister_workspace",
+            "status": "binary_missing",
+            "agent_name": agent_name,
+        }
+    try:
+        proc = subprocess.run(
+            [binary, "agents", "remove", agent_name],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "action": "openclaw_unregister_workspace",
+            "status": "failed",
+            "agent_name": agent_name,
+            "stderr": "timed out after 30s",
+        }
+    combined = (proc.stdout or "") + (proc.stderr or "")
+    if proc.returncode == 0 or "not found" in combined.lower():
+        return {
+            "action": "openclaw_unregister_workspace",
+            "status": "ok",
+            "agent_name": agent_name,
+        }
+    return {
+        "action": "openclaw_unregister_workspace",
+        "status": "failed",
+        "agent_name": agent_name,
+        "exit_code": proc.returncode,
+        "stderr": combined.strip()[:500],
+    }
+
+
+# Registry: action name -> (run_fn, reverse_fn)
+ACTIONS: dict[str, tuple[Callable, Callable | None]] = {
+    "openclaw_register_workspace": (openclaw_register_workspace, openclaw_unregister_workspace),
+}
+
+
+def run(action_name: str, target_root: Path | str, **kwargs) -> dict:
+    if action_name not in ACTIONS:
+        return {
+            "action": action_name,
+            "status": "unknown_action",
+            "stderr": f"no built-in named '{action_name}'",
+        }
+    fn, _ = ACTIONS[action_name]
+    return fn(target_root, **kwargs)
+
+
+def reverse(action_name: str, target_root: Path | str, **kwargs) -> dict:
+    if action_name not in ACTIONS:
+        return {"action": action_name, "status": "unknown_action"}
+    _, rev_fn = ACTIONS[action_name]
+    if rev_fn is None:
+        return {"action": action_name, "status": "no_reverse_defined"}
+    return rev_fn(target_root, **kwargs)

--- a/harness_manager/post_install.py
+++ b/harness_manager/post_install.py
@@ -9,6 +9,7 @@ codex review of the v1.0 vision plan flagged generalized run_command as
 DSL creep; named built-ins are the constrained alternative.
 """
 import hashlib
+import os
 import platform
 import re
 import shutil
@@ -26,7 +27,20 @@ _OPENCLAW_AGENT_NAME_ALLOWED = set(string.ascii_letters + string.digits + "._-")
 
 
 def _abs_target(target_root: Path | str) -> Path:
-    return Path(target_root).resolve()
+    """Absolute, dot-normalized path WITHOUT resolving symlinks.
+
+    Mirrors `cd "$TARGET" && pwd` from the legacy install.sh — POSIX `pwd`
+    defaults to the LOGICAL path (`-L`), preserving the symlink chain the
+    user invoked from. `Path.resolve()` is the wrong choice here because
+    it canonicalizes symlinks; if a user's workspace lives at e.g.
+    `~/src/app` (a symlink into another volume), `resolve()` returns the
+    target of the symlink, the cksum of that path differs from the cksum
+    of the original, and openclaw_register_workspace registers a SECOND
+    agent on upgrade. `os.path.abspath()` does what `cd && pwd` does:
+    normalizes `.` and `..`, prepends cwd if relative, but never reads
+    the filesystem to resolve symlinks.
+    """
+    return Path(os.path.abspath(str(target_root)))
 
 
 # POSIX cksum CRC-32 table. Polynomial 0x04C11DB7, no inversion, length-tagged.

--- a/harness_manager/remove.py
+++ b/harness_manager/remove.py
@@ -45,6 +45,7 @@ def remove(
     files_to_delete = list(entry.get("files_written", []))
     files_to_preserve = list(entry.get("files_overwritten", []))
     skills_link = entry.get("skills_link")
+    skills_link_pre_existed = entry.get("skills_link_pre_existed", False)
     post_install_results = entry.get("post_install_results", [])
 
     log(f"removing adapter '{adapter_name}' from {target_root}")
@@ -56,7 +57,10 @@ def remove(
         marker = "(missing)" if not (target_root / f).exists() else ""
         log(f"  - {f} {marker}".rstrip())
     if skills_link:
-        log(f"  - {skills_link['dst']} (skills_link, will be unlinked/removed)")
+        if skills_link_pre_existed:
+            log(f"  ~ {skills_link['dst']} (skills_link target pre-existed install — PRESERVED)")
+        else:
+            log(f"  - {skills_link['dst']} (skills_link, will be unlinked/removed)")
     if files_to_preserve:
         log("")
         log("the following files were modified by install but pre-existed in your project")
@@ -106,8 +110,11 @@ def remove(
             except OSError as e:
                 log(f"  ! could not delete {f}: {e}")
 
-    # Remove skills_link (only the link/dir, not the target!)
-    if skills_link:
+    # Remove skills_link (only the link/dir, not the target!) — but only
+    # if the destination did NOT pre-exist install. If user had their own
+    # `.agents/skills/` or `.pi/skills/` before installing, we adopted it
+    # via rsync sync, but it's still theirs to keep on remove.
+    if skills_link and not skills_link_pre_existed:
         dst = target_root / skills_link["dst"]
         try:
             if dst.is_symlink():
@@ -118,11 +125,26 @@ def remove(
                 log(f"  - removed dir {skills_link['dst']}")
         except OSError as e:
             log(f"  ! could not remove {skills_link['dst']}: {e}")
+    elif skills_link and skills_link_pre_existed:
+        log(
+            f"  ~ leaving {skills_link['dst']} alone (it pre-existed install — "
+            f"may be user-owned content the installer adopted)"
+        )
 
-    # Reverse post_install actions
+    # Reverse post_install actions. Pass through any state recorded at
+    # install time (e.g. the openclaw agent_name) so the reverse targets
+    # the original registration even if the project has been moved or
+    # renamed since install.
     for action_name in reverse_actions:
         log(f"  → reversing {action_name}")
-        result = post_install_mod.reverse(action_name, target_root)
+        # Find the matching install-time result so we can forward its
+        # recorded fields (agent_name, etc.) as kwargs.
+        recorded = next(
+            (r for r in post_install_results if r.get("action") == action_name),
+            {},
+        )
+        kwargs = {k: v for k, v in recorded.items() if k not in ("action", "status", "stderr", "exit_code", "fallback_hint")}
+        result = post_install_mod.reverse(action_name, target_root, **kwargs)
         st = result.get("status", "?")
         if st == "ok":
             log(f"    ✓ reversed")

--- a/harness_manager/remove.py
+++ b/harness_manager/remove.py
@@ -1,0 +1,122 @@
+"""Remove an installed adapter from a project.
+
+Confirm prompt lists every file before deleting. Hard delete (no
+quarantine — codex UX framing: don't over-help, no undo machinery
+to learn or trust). User runs `git reset` if they want recovery.
+"""
+import shutil
+import sys
+from pathlib import Path
+from typing import Callable
+
+from . import post_install as post_install_mod
+from . import state as state_mod
+
+
+def remove(
+    target_root: Path | str,
+    adapter_name: str,
+    yes: bool = False,
+    log: Callable[[str], None] | None = None,
+) -> int:
+    """Remove `adapter_name` from `target_root`. Returns exit code.
+
+    yes=True skips the confirm prompt (CI / scripted use).
+    """
+    if log is None:
+        log = print
+    target_root = Path(target_root).resolve()
+
+    doc = state_mod.load(target_root)
+    if doc is None:
+        log(f"no install.json at {target_root / '.agent/install.json'}; "
+            "nothing tracked to remove.")
+        return 1
+    if adapter_name not in doc.get("adapters", {}):
+        log(f"adapter '{adapter_name}' is not in install.json. "
+            f"installed: {sorted(doc.get('adapters', {}).keys())}")
+        return 1
+
+    entry = doc["adapters"][adapter_name]
+    files_to_delete = list(entry.get("files_written", []))
+    skills_link = entry.get("skills_link")
+    post_install_results = entry.get("post_install_results", [])
+
+    log(f"removing adapter '{adapter_name}' from {target_root}")
+    log("")
+    log("the following files will be DELETED (no quarantine, no undo):")
+    if not files_to_delete and not skills_link:
+        log("  (no files tracked — adapter entry will just be removed from install.json)")
+    for f in files_to_delete:
+        marker = "(missing)" if not (target_root / f).exists() else ""
+        log(f"  - {f} {marker}".rstrip())
+    if skills_link:
+        log(f"  - {skills_link['dst']} (skills_link, will be unlinked/removed)")
+    log("")
+
+    # Reverse post_install actions
+    reverse_actions = []
+    for r in post_install_results:
+        action = r.get("action")
+        if action and action in post_install_mod.ACTIONS:
+            reverse_actions.append(action)
+    if reverse_actions:
+        log("the following post-install state will be reversed:")
+        for a in reverse_actions:
+            log(f"  - {a} → reverse")
+        log("")
+
+    if not yes:
+        if not sys.stdin.isatty():
+            log("non-interactive shell and --yes not given; aborting for safety.")
+            return 1
+        try:
+            answer = input("proceed? [y/N]: ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            log("")
+            log("aborted; no changes.")
+            return 0
+        if answer not in ("y", "yes"):
+            log("aborted; no changes.")
+            return 0
+
+    # Delete files
+    for f in files_to_delete:
+        p = target_root / f
+        if p.is_file() or p.is_symlink():
+            try:
+                p.unlink()
+                log(f"  - deleted {f}")
+            except OSError as e:
+                log(f"  ! could not delete {f}: {e}")
+
+    # Remove skills_link (only the link/dir, not the target!)
+    if skills_link:
+        dst = target_root / skills_link["dst"]
+        try:
+            if dst.is_symlink():
+                dst.unlink()
+                log(f"  - unlinked {skills_link['dst']}")
+            elif dst.is_dir():
+                shutil.rmtree(dst)
+                log(f"  - removed dir {skills_link['dst']}")
+        except OSError as e:
+            log(f"  ! could not remove {skills_link['dst']}: {e}")
+
+    # Reverse post_install actions
+    for action_name in reverse_actions:
+        log(f"  → reversing {action_name}")
+        result = post_install_mod.reverse(action_name, target_root)
+        st = result.get("status", "?")
+        if st == "ok":
+            log(f"    ✓ reversed")
+        elif st == "binary_missing":
+            log(f"    ~ binary not on PATH; reverse skipped (manual cleanup may be needed)")
+        else:
+            log(f"    ! {st}: {result.get('stderr', '')}")
+
+    # Drop from install.json
+    state_mod.remove_adapter(target_root, adapter_name)
+    log("")
+    log(f"removed '{adapter_name}'.")
+    return 0

--- a/harness_manager/remove.py
+++ b/harness_manager/remove.py
@@ -38,7 +38,12 @@ def remove(
         return 1
 
     entry = doc["adapters"][adapter_name]
+    # Only delete files we created. Files that pre-existed (e.g., the
+    # user's own AGENTS.md, settings.json, run.py) are tracked in
+    # files_overwritten and we leave them alone — destroying a user's
+    # pre-install file is exactly the kind of thing remove must NOT do.
     files_to_delete = list(entry.get("files_written", []))
+    files_to_preserve = list(entry.get("files_overwritten", []))
     skills_link = entry.get("skills_link")
     post_install_results = entry.get("post_install_results", [])
 
@@ -46,12 +51,18 @@ def remove(
     log("")
     log("the following files will be DELETED (no quarantine, no undo):")
     if not files_to_delete and not skills_link:
-        log("  (no files tracked — adapter entry will just be removed from install.json)")
+        log("  (no files tracked for cleanup — adapter entry will just be removed from install.json)")
     for f in files_to_delete:
         marker = "(missing)" if not (target_root / f).exists() else ""
         log(f"  - {f} {marker}".rstrip())
     if skills_link:
         log(f"  - {skills_link['dst']} (skills_link, will be unlinked/removed)")
+    if files_to_preserve:
+        log("")
+        log("the following files were modified by install but pre-existed in your project")
+        log("and will be PRESERVED (we never delete user-owned content):")
+        for f in files_to_preserve:
+            log(f"  ~ {f} (use git or your own backup to recover the original if needed)")
     log("")
 
     # Reverse post_install actions

--- a/harness_manager/remove.py
+++ b/harness_manager/remove.py
@@ -65,11 +65,16 @@ def remove(
             log(f"  ~ {f} (use git or your own backup to recover the original if needed)")
     log("")
 
-    # Reverse post_install actions
+    # Reverse post_install actions — but ONLY for actions that succeeded
+    # at install time. Reversing a failed/skipped registration is wrong:
+    # if `openclaw_register_workspace` was binary_missing at install, a
+    # subsequent `openclaw agents remove` could delete a manually-created
+    # agent for the same workspace that was never ours to manage.
     reverse_actions = []
     for r in post_install_results:
         action = r.get("action")
-        if action and action in post_install_mod.ACTIONS:
+        status = r.get("status")
+        if action in post_install_mod.ACTIONS and status in ("ok", "already_exists"):
             reverse_actions.append(action)
     if reverse_actions:
         log("the following post-install state will be reversed:")

--- a/harness_manager/remove.py
+++ b/harness_manager/remove.py
@@ -42,11 +42,41 @@ def remove(
     # user's own AGENTS.md, settings.json, run.py) are tracked in
     # files_overwritten and we leave them alone — destroying a user's
     # pre-install file is exactly the kind of thing remove must NOT do.
-    files_to_delete = list(entry.get("files_written", []))
+    candidate_files_to_delete = list(entry.get("files_written", []))
     files_to_preserve = list(entry.get("files_overwritten", []))
     skills_link = entry.get("skills_link")
     skills_link_pre_existed = entry.get("skills_link_pre_existed", False)
     post_install_results = entry.get("post_install_results", [])
+
+    # Shared-file reference check: if another installed adapter also depends
+    # on a file we're about to delete (their file_results show left_alone /
+    # merge_alert / written_overwrite / written_new for the same dst), we
+    # must NOT delete it. Common case: codex writes AGENTS.md, then opencode
+    # is added later and sees AGENTS.md already references .agent/ → its
+    # file_results record `left_alone`. Removing codex must not orphan
+    # opencode by deleting their shared AGENTS.md.
+    other_adapter_paths: set[str] = set()
+    for other_name, other_entry in doc.get("adapters", {}).items():
+        if other_name == adapter_name:
+            continue
+        # All paths another adapter references in any role:
+        for r in other_entry.get("file_results", []):
+            if r.get("dst"):
+                other_adapter_paths.add(r["dst"])
+        for f in other_entry.get("files_written", []):
+            other_adapter_paths.add(f)
+        for f in other_entry.get("files_overwritten", []):
+            other_adapter_paths.add(f)
+        for f in other_entry.get("files_alerted", []):
+            other_adapter_paths.add(f)
+
+    files_to_delete = []
+    files_shared = []
+    for f in candidate_files_to_delete:
+        if f in other_adapter_paths:
+            files_shared.append(f)
+        else:
+            files_to_delete.append(f)
 
     log(f"removing adapter '{adapter_name}' from {target_root}")
     log("")
@@ -67,6 +97,12 @@ def remove(
         log("and will be PRESERVED (we never delete user-owned content):")
         for f in files_to_preserve:
             log(f"  ~ {f} (use git or your own backup to recover the original if needed)")
+    if files_shared:
+        log("")
+        log("the following files are SHARED with another installed adapter")
+        log("and will be PRESERVED (deleting would break the other adapter):")
+        for f in files_shared:
+            log(f"  ~ {f}")
     log("")
 
     # Reverse post_install actions — but ONLY for actions that succeeded

--- a/harness_manager/remove.py
+++ b/harness_manager/remove.py
@@ -105,16 +105,19 @@ def remove(
             log(f"  ~ {f}")
     log("")
 
-    # Reverse post_install actions — but ONLY for actions that succeeded
-    # at install time. Reversing a failed/skipped registration is wrong:
-    # if `openclaw_register_workspace` was binary_missing at install, a
-    # subsequent `openclaw agents remove` could delete a manually-created
-    # agent for the same workspace that was never ours to manage.
+    # Reverse post_install actions — but ONLY for actions we actually
+    # performed ourselves. status == "ok" means WE ran the registration.
+    # status == "already_exists" means the agent was there BEFORE we
+    # installed (user had manually registered earlier, or they re-ran
+    # install idempotently), so reversing would delete a user-managed
+    # registration we never created. status == "binary_missing" / other
+    # skipped states also never ran the action, so reversing would
+    # delete something that isn't ours.
     reverse_actions = []
     for r in post_install_results:
         action = r.get("action")
         status = r.get("status")
-        if action in post_install_mod.ACTIONS and status in ("ok", "already_exists"):
+        if action in post_install_mod.ACTIONS and status == "ok":
             reverse_actions.append(action)
     if reverse_actions:
         log("the following post-install state will be reversed:")
@@ -188,6 +191,48 @@ def remove(
             log(f"    ~ binary not on PATH; reverse skipped (manual cleanup may be needed)")
         else:
             log(f"    ! {st}: {result.get('stderr', '')}")
+
+    # Ownership handoff for shared files: only transfer when another
+    # adapter PROVABLY wrote the file (file_results recorded written_new
+    # or written_overwrite). Looser criteria — transferring on
+    # left_alone / merge_alert / skipped_existing observations — risks
+    # letting a future `remove B` delete a user-owned file that B just
+    # observed but never wrote. The conservative tradeoff: shared files
+    # whose next owner can't be proved may linger after the last
+    # installed adapter is removed; users can git-clean manually.
+    handoffs: dict[str, list[str]] = {}
+    for f in files_shared:
+        for other_name, other_entry in doc.get("adapters", {}).items():
+            if other_name == adapter_name:
+                continue
+            if (
+                f in other_entry.get("files_written", [])
+                or f in other_entry.get("files_overwritten", [])
+            ):
+                # Already tracked as owned or user-preserved by this
+                # adapter; no handoff needed.
+                break
+            wrote_it = any(
+                r.get("dst") == f
+                and r.get("result") in ("written_new", "written_overwrite")
+                for r in other_entry.get("file_results", [])
+            )
+            if wrote_it:
+                handoffs.setdefault(other_name, []).append(f)
+                break
+    if handoffs:
+        from . import __version__ as _asv
+        version = doc.get("agentic_stack_version", _asv)
+        for other_name, files in handoffs.items():
+            new_entry = dict(doc["adapters"][other_name])
+            new_entry["files_written"] = (
+                list(new_entry.get("files_written", [])) + files
+            )
+            state_mod.upsert_adapter(
+                target_root, other_name, new_entry, version,
+            )
+            for f in files:
+                log(f"  ~ {f}: ownership transferred to {other_name}")
 
     # Drop from install.json
     state_mod.remove_adapter(target_root, adapter_name)

--- a/harness_manager/schema.py
+++ b/harness_manager/schema.py
@@ -1,0 +1,189 @@
+"""adapter.json schema + stdlib-only validator.
+
+Zero deps by design — the repo's other Python touchpoints (onboard.py,
+.agent/tools/*) are all stdlib-only and brew-installed users get raw
+python3 with no pip step. A 50-line recursive checker is cheaper than
+adding a `jsonschema` dependency.
+"""
+import json
+from pathlib import Path
+from typing import Any
+
+
+# Schema version. Bump only when an incompatible change ships.
+SCHEMA_VERSION = 1
+
+VALID_MERGE_POLICIES = {"overwrite", "skip_if_exists", "merge_or_alert"}
+VALID_FALLBACKS = {"rsync_with_delete"}
+VALID_POST_INSTALL_ACTIONS = {"openclaw_register_workspace"}
+
+
+class ManifestError(ValueError):
+    """Raised when adapter.json fails validation. Includes source for context."""
+
+    def __init__(self, source: str, message: str):
+        super().__init__(f"{source}: {message}")
+        self.source = source
+        self.message = message
+
+
+def _require(d: dict, key: str, types: tuple, source: str) -> Any:
+    if key not in d:
+        raise ManifestError(source, f"missing required field '{key}'")
+    val = d[key]
+    if not isinstance(val, types):
+        type_names = " or ".join(t.__name__ for t in types)
+        raise ManifestError(
+            source, f"field '{key}' must be {type_names}, got {type(val).__name__}"
+        )
+    return val
+
+
+def _check_optional(d: dict, key: str, types: tuple, source: str) -> Any:
+    if key not in d:
+        return None
+    val = d[key]
+    if not isinstance(val, types):
+        type_names = " or ".join(t.__name__ for t in types)
+        raise ManifestError(
+            source, f"field '{key}' must be {type_names}, got {type(val).__name__}"
+        )
+    return val
+
+
+def _validate_files(files: list, source: str) -> None:
+    if not files:
+        raise ManifestError(source, "'files' must contain at least one entry")
+    for i, entry in enumerate(files):
+        es = f"{source} files[{i}]"
+        if not isinstance(entry, dict):
+            raise ManifestError(es, "must be an object")
+        src = _require(entry, "src", (str,), es)
+        dst = _require(entry, "dst", (str,), es)
+        if not src or not dst:
+            raise ManifestError(es, "'src' and 'dst' must be non-empty strings")
+        if ".." in src.split("/") or ".." in dst.split("/"):
+            raise ManifestError(es, "'..' path components not allowed (path traversal)")
+        if src.startswith("/") or dst.startswith("/"):
+            raise ManifestError(es, "absolute paths not allowed; use repo-relative paths")
+        policy = _check_optional(entry, "merge_policy", (str,), es)
+        if policy is not None and policy not in VALID_MERGE_POLICIES:
+            raise ManifestError(
+                es, f"merge_policy must be one of {sorted(VALID_MERGE_POLICIES)}, got '{policy}'"
+            )
+        _check_optional(entry, "substitute", (bool,), es)
+        _check_optional(entry, "from_stack", (bool,), es)
+
+
+def _validate_skills_link(link: dict, source: str) -> None:
+    if not isinstance(link, dict):
+        raise ManifestError(source, "'skills_link' must be an object")
+    target = _require(link, "target", (str,), f"{source} skills_link")
+    dst = _require(link, "dst", (str,), f"{source} skills_link")
+    if not target or not dst:
+        raise ManifestError(f"{source} skills_link", "'target' and 'dst' must be non-empty")
+    fallback = _check_optional(link, "fallback", (str,), f"{source} skills_link")
+    if fallback is not None and fallback not in VALID_FALLBACKS:
+        raise ManifestError(
+            f"{source} skills_link",
+            f"fallback must be one of {sorted(VALID_FALLBACKS)}, got '{fallback}'",
+        )
+
+
+def _validate_post_install(actions: list, source: str) -> None:
+    for i, action in enumerate(actions):
+        if not isinstance(action, str):
+            raise ManifestError(
+                f"{source} post_install[{i}]",
+                f"must be a string naming a built-in action, got {type(action).__name__}",
+            )
+        if action not in VALID_POST_INSTALL_ACTIONS:
+            raise ManifestError(
+                f"{source} post_install[{i}]",
+                f"unknown action '{action}'; valid: {sorted(VALID_POST_INSTALL_ACTIONS)}",
+            )
+
+
+def validate_dict(manifest: Any, source: str) -> dict:
+    """Validate an in-memory manifest dict. Returns the dict on success."""
+    if not isinstance(manifest, dict):
+        raise ManifestError(source, f"manifest must be a JSON object, got {type(manifest).__name__}")
+
+    name = _require(manifest, "name", (str,), source)
+    _require(manifest, "description", (str,), source)
+    files = _require(manifest, "files", (list,), source)
+
+    if not name or not name.replace("-", "").replace("_", "").isalnum():
+        raise ManifestError(
+            source, f"'name' must be non-empty alphanumeric (with - or _), got '{name}'"
+        )
+
+    _validate_files(files, source)
+
+    skills_link = _check_optional(manifest, "skills_link", (dict,), source)
+    if skills_link is not None:
+        _validate_skills_link(skills_link, source)
+
+    post_install = _check_optional(manifest, "post_install", (list,), source)
+    if post_install is not None:
+        _validate_post_install(post_install, source)
+
+    primitive = _check_optional(manifest, "brain_root_primitive", (str, type(None)), source)
+    if primitive is not None and not primitive.startswith("$"):
+        raise ManifestError(
+            source,
+            f"brain_root_primitive must be a shell env var reference like '$CLAUDE_PROJECT_DIR', "
+            f"got '{primitive}'",
+        )
+
+    # Reject unknown top-level keys to catch typos early.
+    known = {
+        "name", "description", "files", "skills_link",
+        "post_install", "brain_root_primitive",
+    }
+    extras = set(manifest.keys()) - known
+    if extras:
+        raise ManifestError(source, f"unknown top-level field(s): {sorted(extras)}")
+
+    return manifest
+
+
+def validate(manifest_path: Path | str) -> dict:
+    """Load and validate adapter.json from a path. Returns the parsed dict."""
+    p = Path(manifest_path)
+    if not p.is_file():
+        raise ManifestError(str(p), "file not found")
+    try:
+        text = p.read_text(encoding="utf-8")
+    except OSError as e:
+        raise ManifestError(str(p), f"unreadable: {e}") from e
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as e:
+        raise ManifestError(str(p), f"invalid JSON: {e.msg} at line {e.lineno}") from e
+    # Use the dir name as the source label so error messages are more useful
+    # ("adapters/claude-code/adapter.json" beats "/abs/path/.../adapter.json").
+    label = str(p.relative_to(p.parents[2])) if len(p.parents) >= 3 else str(p)
+    return validate_dict(data, label)
+
+
+def discover_all(repo_root: Path | str) -> list[tuple[str, dict]]:
+    """Return (adapter_name, manifest_dict) for every adapter with adapter.json.
+
+    Adapters without adapter.json are skipped silently — they're not
+    manifest-driven yet (during the migration window, this is allowed).
+    """
+    root = Path(repo_root)
+    adapters_dir = root / "adapters"
+    out = []
+    if not adapters_dir.is_dir():
+        return out
+    for adapter_dir in sorted(adapters_dir.iterdir()):
+        if not adapter_dir.is_dir():
+            continue
+        manifest_path = adapter_dir / "adapter.json"
+        if not manifest_path.is_file():
+            continue
+        manifest = validate(manifest_path)
+        out.append((adapter_dir.name, manifest))
+    return out

--- a/harness_manager/state.py
+++ b/harness_manager/state.py
@@ -1,0 +1,122 @@
+"""install.json: the authoritative record of what's installed in a project.
+
+Atomic write via temp-file + rename, with fcntl advisory lock on POSIX.
+Read-modify-write semantics (unlike .agent/memory/episodic/AGENT_LEARNINGS.jsonl
+which is append-only). Codex review of PR #19 specifically called out that
+the _episodic_io flock pattern is the wrong abstraction for install.json
+because of read-modify-write — this module uses the right one.
+"""
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+try:
+    import fcntl  # POSIX
+    _HAVE_FLOCK = True
+except ImportError:
+    _HAVE_FLOCK = False
+
+
+SCHEMA_VERSION = 1
+
+
+def install_state_path(target_root: Path | str) -> Path:
+    """Return the path where install.json lives for a given project."""
+    return Path(target_root) / ".agent" / "install.json"
+
+
+def load(target_root: Path | str) -> dict | None:
+    """Load install.json for a project. Returns None if absent."""
+    p = install_state_path(target_root)
+    if not p.is_file():
+        return None
+    with open(p, "r", encoding="utf-8") as f:
+        if _HAVE_FLOCK:
+            fcntl.flock(f.fileno(), fcntl.LOCK_SH)
+        try:
+            return json.load(f)
+        finally:
+            if _HAVE_FLOCK:
+                fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+
+def empty(target_root: Path | str, agentic_stack_version: str) -> dict:
+    """Return a fresh install.json doc."""
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "agentic_stack_version": agentic_stack_version,
+        "abs_target": str(Path(target_root).resolve()),
+        "installed_at": _iso_now(),
+        "adapters": {},
+    }
+
+
+def save(target_root: Path | str, doc: dict) -> None:
+    """Atomically write install.json. fcntl-locked on POSIX.
+
+    Atomic-replace via tempfile + os.rename in the same directory ensures
+    readers never see a torn write. The flock is for cross-process
+    serialization of read-modify-write callers.
+    """
+    p = install_state_path(target_root)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    payload = (json.dumps(doc, indent=2) + "\n").encode("utf-8")
+
+    # Lock-file pattern: take an exclusive lock on a sibling .lock file
+    # so concurrent writers serialize. Atomic rename is the actual
+    # commit. Don't lock install.json itself — the rename would replace
+    # the locked inode mid-flight.
+    lock_path = p.with_suffix(p.suffix + ".lock")
+    with open(lock_path, "a+") as lock_f:
+        if _HAVE_FLOCK:
+            fcntl.flock(lock_f.fileno(), fcntl.LOCK_EX)
+        try:
+            fd, tmp = tempfile.mkstemp(
+                dir=str(p.parent), prefix=".install.json.", suffix=".tmp"
+            )
+            try:
+                with os.fdopen(fd, "wb") as tf:
+                    tf.write(payload)
+                    tf.flush()
+                    os.fsync(tf.fileno())
+                os.replace(tmp, p)
+            except Exception:
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
+                raise
+        finally:
+            if _HAVE_FLOCK:
+                fcntl.flock(lock_f.fileno(), fcntl.LOCK_UN)
+
+
+def upsert_adapter(
+    target_root: Path | str,
+    adapter_name: str,
+    entry: dict,
+    agentic_stack_version: str,
+) -> None:
+    """Read-modify-write to add or replace one adapter entry."""
+    doc = load(target_root) or empty(target_root, agentic_stack_version)
+    doc["adapters"][adapter_name] = entry
+    doc["installed_at"] = _iso_now()
+    save(target_root, doc)
+
+
+def remove_adapter(target_root: Path | str, adapter_name: str) -> bool:
+    """Drop an adapter from install.json. Returns True if present, False if not."""
+    doc = load(target_root)
+    if doc is None or adapter_name not in doc.get("adapters", {}):
+        return False
+    del doc["adapters"][adapter_name]
+    doc["installed_at"] = _iso_now()
+    save(target_root, doc)
+    return True
+
+
+def _iso_now() -> str:
+    import datetime as _dt
+    return _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/harness_manager/state.py
+++ b/harness_manager/state.py
@@ -57,40 +57,70 @@ def save(target_root: Path | str, doc: dict) -> None:
     """Atomically write install.json. fcntl-locked on POSIX.
 
     Atomic-replace via tempfile + os.rename in the same directory ensures
-    readers never see a torn write. The flock is for cross-process
-    serialization of read-modify-write callers.
+    readers never see a torn write.
+
+    NOTE: this function takes the writer lock for its own duration only.
+    For correct read-modify-write callers (upsert_adapter / remove_adapter),
+    use those — they hold the lock around BOTH the read and the save so
+    concurrent writers can't lose updates.
     """
     p = install_state_path(target_root)
     p.parent.mkdir(parents=True, exist_ok=True)
-    payload = (json.dumps(doc, indent=2) + "\n").encode("utf-8")
+    with _lock(p):
+        _save_locked(p, doc)
 
-    # Lock-file pattern: take an exclusive lock on a sibling .lock file
-    # so concurrent writers serialize. Atomic rename is the actual
-    # commit. Don't lock install.json itself — the rename would replace
-    # the locked inode mid-flight.
-    lock_path = p.with_suffix(p.suffix + ".lock")
-    with open(lock_path, "a+") as lock_f:
-        if _HAVE_FLOCK:
-            fcntl.flock(lock_f.fileno(), fcntl.LOCK_EX)
+
+def _save_locked(p: Path, doc: dict) -> None:
+    """Inner save: caller already holds the lock. tempfile + atomic rename."""
+    payload = (json.dumps(doc, indent=2) + "\n").encode("utf-8")
+    fd, tmp = tempfile.mkstemp(dir=str(p.parent), prefix=".install.json.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "wb") as tf:
+            tf.write(payload)
+            tf.flush()
+            os.fsync(tf.fileno())
+        os.replace(tmp, p)
+    except Exception:
         try:
-            fd, tmp = tempfile.mkstemp(
-                dir=str(p.parent), prefix=".install.json.", suffix=".tmp"
-            )
-            try:
-                with os.fdopen(fd, "wb") as tf:
-                    tf.write(payload)
-                    tf.flush()
-                    os.fsync(tf.fileno())
-                os.replace(tmp, p)
-            except Exception:
-                try:
-                    os.unlink(tmp)
-                except OSError:
-                    pass
-                raise
-        finally:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+class _lock:
+    """Context manager: take an exclusive flock on a sibling .lock file.
+
+    Don't lock install.json itself — the atomic rename would replace
+    the locked inode mid-flight, leaving us holding a lock on a deleted
+    file while the new install.json sits unlocked.
+    """
+
+    def __init__(self, install_json_path: Path):
+        self.install_json_path = install_json_path
+        self.lock_path = install_json_path.with_suffix(install_json_path.suffix + ".lock")
+        self.lock_f = None
+
+    def __enter__(self):
+        self.install_json_path.parent.mkdir(parents=True, exist_ok=True)
+        self.lock_f = open(self.lock_path, "a+")
+        if _HAVE_FLOCK:
+            fcntl.flock(self.lock_f.fileno(), fcntl.LOCK_EX)
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        if self.lock_f is not None:
             if _HAVE_FLOCK:
-                fcntl.flock(lock_f.fileno(), fcntl.LOCK_UN)
+                fcntl.flock(self.lock_f.fileno(), fcntl.LOCK_UN)
+            self.lock_f.close()
+
+
+def _load_no_lock(p: Path) -> dict | None:
+    """Read install.json. Caller holds the lock OR is fine with eventual consistency."""
+    if not p.is_file():
+        return None
+    with open(p, "r", encoding="utf-8") as f:
+        return json.load(f)
 
 
 def upsert_adapter(
@@ -99,22 +129,34 @@ def upsert_adapter(
     entry: dict,
     agentic_stack_version: str,
 ) -> None:
-    """Read-modify-write to add or replace one adapter entry."""
-    doc = load(target_root) or empty(target_root, agentic_stack_version)
-    doc["adapters"][adapter_name] = entry
-    doc["installed_at"] = _iso_now()
-    save(target_root, doc)
+    """Read-modify-write to add or replace one adapter entry.
+
+    Lock is held around the ENTIRE read-modify-write so concurrent
+    `install.sh add ...` invocations cannot both read the same old
+    document and produce a lost update.
+    """
+    p = install_state_path(target_root)
+    with _lock(p):
+        doc = _load_no_lock(p) or empty(target_root, agentic_stack_version)
+        doc["adapters"][adapter_name] = entry
+        doc["installed_at"] = _iso_now()
+        _save_locked(p, doc)
 
 
 def remove_adapter(target_root: Path | str, adapter_name: str) -> bool:
-    """Drop an adapter from install.json. Returns True if present, False if not."""
-    doc = load(target_root)
-    if doc is None or adapter_name not in doc.get("adapters", {}):
-        return False
-    del doc["adapters"][adapter_name]
-    doc["installed_at"] = _iso_now()
-    save(target_root, doc)
-    return True
+    """Drop an adapter from install.json. Returns True if present, False if not.
+
+    Same locking discipline as upsert_adapter: lock spans the read+write.
+    """
+    p = install_state_path(target_root)
+    with _lock(p):
+        doc = _load_no_lock(p)
+        if doc is None or adapter_name not in doc.get("adapters", {}):
+            return False
+        del doc["adapters"][adapter_name]
+        doc["installed_at"] = _iso_now()
+        _save_locked(p, doc)
+        return True
 
 
 def _iso_now() -> str:

--- a/harness_manager/state.py
+++ b/harness_manager/state.py
@@ -15,8 +15,14 @@ from typing import Any
 try:
     import fcntl  # POSIX
     _HAVE_FLOCK = True
+    _HAVE_MSVCRT = False
 except ImportError:
     _HAVE_FLOCK = False
+    try:
+        import msvcrt  # Windows
+        _HAVE_MSVCRT = True
+    except ImportError:
+        _HAVE_MSVCRT = False
 
 
 SCHEMA_VERSION = 1
@@ -25,6 +31,75 @@ SCHEMA_VERSION = 1
 def install_state_path(target_root: Path | str) -> Path:
     """Return the path where install.json lives for a given project."""
     return Path(target_root) / ".agent" / "install.json"
+
+
+def brain_present(target_root: Path | str) -> bool:
+    """True if .agent/ has the distinctive agentic-stack brain layout.
+
+    Checking for `.agent/` alone false-positives on projects that use
+    `.agent/` for unrelated purposes (some repos adopt the convention
+    generically). We require the characteristic subdir triple that
+    only the agentic-stack brain template installs: memory/, skills/,
+    and protocols/. If all three are directories, the brain template
+    was dropped here at some point.
+
+    NOTE: brain-present is NECESSARY but NOT SUFFICIENT for legacy-
+    install detection — a user could clone the agentic-stack repo
+    itself, or copy the brain template into a repo, without ever
+    installing an adapter. Use `legacy_unregistered_adapters` when
+    you need to actually gate against a pre-v0.9 install.
+    """
+    agent = Path(target_root) / ".agent"
+    if not agent.is_dir():
+        return False
+    return (
+        (agent / "memory").is_dir()
+        and (agent / "skills").is_dir()
+        and (agent / "protocols").is_dir()
+    )
+
+
+def legacy_unregistered_adapters(target_root: Path | str) -> list[str]:
+    """Detect pre-v0.9 install(s): returns the list of adapter signals.
+
+    Returns [] when the project is NOT a legacy install — either
+    install.json exists (already tracked), or the brain isn't present
+    (fresh repo), or the brain is present but no adapter signals are
+    on disk (brain-only template, nothing to migrate).
+
+    Returns a sorted list of adapter names when the project needs
+    migration via `doctor`. Caller gates installs on truthiness.
+
+    We require BOTH a distinctive brain layout AND at least one
+    adapter signal. Brain-only (e.g. cloning agentic-stack itself,
+    or copying the template into a fresh repo before any adapter
+    install) is NOT a legacy install — there's nothing to migrate,
+    and gating would deadlock the user since doctor synthesizes
+    nothing when no signals exist.
+    """
+    p = install_state_path(target_root)
+    if p.is_file():
+        return []
+    if not brain_present(target_root):
+        return []
+    # Lazy import: doctor imports state, so inverse would cycle.
+    from . import doctor as doctor_mod
+    # STRONG signals only. Weak signals (plain CLAUDE.md / AGENTS.md /
+    # run.py) are ambiguous even in a brain-present repo: users may
+    # have the brain template from cloning agentic-stack AND their own
+    # AGENTS.md. Gating on weak signals there false-refuses. Weak-only
+    # adapters (hermes, standalone-python) won't auto-gate on upgrade
+    # from pre-v0.9, but `./install.sh doctor` (which DOES consider
+    # weak signals) is the documented path for legacy migration.
+    return sorted(
+        name
+        for name, signals in doctor_mod.DETECT_SIGNALS.items()
+        if any(
+            (Path(target_root) / f).exists()
+            for f, strength in signals
+            if strength == "strong"
+        )
+    )
 
 
 def load(target_root: Path | str) -> dict | None:
@@ -106,12 +181,30 @@ class _lock:
         self.lock_f = open(self.lock_path, "a+")
         if _HAVE_FLOCK:
             fcntl.flock(self.lock_f.fileno(), fcntl.LOCK_EX)
+        elif _HAVE_MSVCRT:
+            # Windows: lock 1 byte at offset 0 of the lock sidecar.
+            # LK_LOCK blocks until acquired (vs LK_NBLCK which would
+            # raise immediately). Byte-range locking is the only
+            # cross-process locking primitive msvcrt exposes, but a
+            # 1-byte span on the sidecar file is enough for our
+            # read-modify-write semantics here.
+            self.lock_f.seek(0)
+            msvcrt.locking(self.lock_f.fileno(), msvcrt.LK_LOCK, 1)
         return self
 
     def __exit__(self, exc_type, exc, tb):
         if self.lock_f is not None:
             if _HAVE_FLOCK:
                 fcntl.flock(self.lock_f.fileno(), fcntl.LOCK_UN)
+            elif _HAVE_MSVCRT:
+                try:
+                    self.lock_f.seek(0)
+                    msvcrt.locking(self.lock_f.fileno(), msvcrt.LK_UNLCK, 1)
+                except OSError:
+                    # Unlock can fail if the handle is already closed
+                    # by a crashed caller; the OS releases the lock on
+                    # process exit anyway.
+                    pass
             self.lock_f.close()
 
 

--- a/harness_manager/status.py
+++ b/harness_manager/status.py
@@ -1,0 +1,64 @@
+"""One-screen read-only view of installed adapters.
+
+Same content as the manage menu's header pane in the v1.0 vision —
+shipped here as a discrete subcommand instead of a TUI element.
+"""
+from pathlib import Path
+from typing import Callable
+
+from . import state as state_mod
+
+
+def show(target_root: Path | str, log: Callable[[str], None] | None = None) -> int:
+    if log is None:
+        log = print
+    target_root = Path(target_root).resolve()
+    doc = state_mod.load(target_root)
+
+    if doc is None:
+        log(f"no install.json at {target_root / '.agent/install.json'}.")
+        log("run `./install.sh <adapter>` to install one,")
+        log("or `./install.sh doctor` to detect existing adapters.")
+        return 0
+
+    adapters = doc.get("adapters", {})
+    log(f"project:  {target_root}")
+    log(f"brain:    .agent/  ({_brain_summary(target_root)})")
+    log(f"version:  agentic-stack {doc.get('agentic_stack_version', '?')}")
+    log(f"updated:  {doc.get('installed_at', '?')}")
+    log("")
+    log(f"adapters installed ({len(adapters)}):")
+    if not adapters:
+        log("  (none)")
+        return 0
+    for name in sorted(adapters):
+        entry = adapters[name]
+        primitive = entry.get("brain_root_primitive", "")
+        prim_str = f"  primitive: {primitive}" if primitive else ""
+        synth = "  (synthesized)" if entry.get("_synthesized") else ""
+        log(f"  • {name}{prim_str}{synth}")
+    return 0
+
+
+def _brain_summary(target_root: Path) -> str:
+    """Quick stats: skill count, episodic line count, lesson count."""
+    parts = []
+    skills_dir = target_root / ".agent" / "skills"
+    if skills_dir.is_dir():
+        n = sum(1 for p in skills_dir.iterdir() if p.is_dir() and (p / "SKILL.md").is_file())
+        parts.append(f"{n} skills")
+    epi = target_root / ".agent" / "memory" / "episodic" / "AGENT_LEARNINGS.jsonl"
+    if epi.is_file():
+        try:
+            n = sum(1 for _ in epi.open("r", encoding="utf-8", errors="ignore"))
+            parts.append(f"{n} episodic")
+        except OSError:
+            pass
+    lessons = target_root / ".agent" / "memory" / "semantic" / "lessons.jsonl"
+    if lessons.is_file():
+        try:
+            n = sum(1 for _ in lessons.open("r", encoding="utf-8", errors="ignore"))
+            parts.append(f"{n} lessons")
+        except OSError:
+            pass
+    return ", ".join(parts) if parts else "uninitialized"

--- a/install.ps1
+++ b/install.ps1
@@ -1,18 +1,30 @@
-# install.ps1 — Windows PowerShell installer (parallel to install.sh)
-# Usage:  .\install.ps1 <adapter-name> [target-dir] [-Yes] [-Reconfigure] [-Force]
-#   adapter-name: claude-code | cursor | windsurf | opencode | openclaw | hermes | pi | codex | standalone-python | antigravity
-#   target-dir:   where your project lives (default: current dir)
-#   -Yes          accept all wizard defaults (safe for CI)
-#   -Reconfigure  re-run the wizard on an existing project
-#   -Force        overwrite even customized PREFERENCES.md
+# install.ps1 — agentic-stack installer (Windows PowerShell parallel to install.sh)
+#
+# Usage:
+#   .\install.ps1 <adapter-name> [target-dir] [-Yes] [-Reconfigure] [-Force]
+#                                              # install one adapter
+#   .\install.ps1 add <adapter-name> [target-dir]
+#                                              # add an adapter to an
+#                                              # already-set-up project
+#   .\install.ps1 remove <adapter-name> [target-dir] [-Yes]
+#                                              # remove an installed adapter
+#   .\install.ps1 doctor [target-dir]          # read-only audit
+#   .\install.ps1 status [target-dir]          # one-screen view
+#   .\install.ps1                              # bare: list adapters / what
+#                                              # to add
+#
+# adapter-name: claude-code | cursor | windsurf | opencode | openclaw |
+#               hermes | pi | codex | standalone-python | antigravity
+#
+# All real logic lives in harness_manager/ (Python). This script is a
+# thin dispatcher so install.sh and install.ps1 share one backend —
+# manifest semantics, file substitution, openclaw_register_workspace,
+# install.json — all behave identically across platforms.
 
-[CmdletBinding()]
+[CmdletBinding(PositionalBinding = $false)]
 param(
-    [Parameter(Mandatory = $true, Position = 0)]
-    [string]$Adapter,
-
-    [Parameter(Position = 1)]
-    [string]$TargetDir = (Get-Location).Path,
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$Args,
 
     [switch]$Yes,
     [switch]$Reconfigure,
@@ -21,272 +33,38 @@ param(
 
 $ErrorActionPreference = 'Stop'
 $Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$env:AGENTIC_STACK_ROOT = $Here
 
-$ValidAdapters = @(
-    'claude-code', 'cursor', 'windsurf',
-    'opencode', 'openclaw', 'hermes', 'pi', 'codex',
-    'standalone-python', 'antigravity'
-)
-if ($Adapter -notin $ValidAdapters) {
-    Write-Error "unknown adapter '$Adapter'. valid: $($ValidAdapters -join ' ')"
-    exit 1
+# Prepend Here to PYTHONPATH so `python -m harness_manager.cli` resolves
+# the module regardless of which directory the user invoked from.
+if ($env:PYTHONPATH) {
+    $env:PYTHONPATH = "$Here;$($env:PYTHONPATH)"
+} else {
+    $env:PYTHONPATH = $Here
 }
 
-$Src = Join-Path $Here "adapters/$Adapter"
-if (-not (Test-Path $Src -PathType Container)) {
-    Write-Error "adapter '$Adapter' not found at $Src"
-    exit 1
-}
-
-Write-Host "installing '$Adapter' into $TargetDir"
-
-# Copy .agent/ brain only if the target does not already have one
-$TargetAgent = Join-Path $TargetDir ".agent"
-if (-not (Test-Path $TargetAgent -PathType Container)) {
-    Copy-Item -Path (Join-Path $Here ".agent") -Destination $TargetAgent -Recurse
-    Write-Host "  + .agent/ (portable brain)"
-}
-
-switch ($Adapter) {
-    'claude-code' {
-        Copy-Item (Join-Path $Src 'CLAUDE.md') (Join-Path $TargetDir 'CLAUDE.md') -Force
-        $claudeDir = Join-Path $TargetDir '.claude'
-        New-Item -ItemType Directory -Path $claudeDir -Force | Out-Null
-        Copy-Item (Join-Path $Src 'settings.json') (Join-Path $claudeDir 'settings.json') -Force
-    }
-    'cursor' {
-        $rulesDir = Join-Path $TargetDir '.cursor/rules'
-        New-Item -ItemType Directory -Path $rulesDir -Force | Out-Null
-        Copy-Item (Join-Path $Src '.cursor/rules/agentic-stack.mdc') (Join-Path $rulesDir 'agentic-stack.mdc') -Force
-    }
-    'windsurf' {
-        Copy-Item (Join-Path $Src '.windsurfrules') (Join-Path $TargetDir '.windsurfrules') -Force
-    }
-    'opencode' {
-        Copy-Item (Join-Path $Src 'AGENTS.md') (Join-Path $TargetDir 'AGENTS.md') -Force
-        Copy-Item (Join-Path $Src 'opencode.json') (Join-Path $TargetDir 'opencode.json') -Force
-    }
-    'openclaw' {
-        # 1. Backward-compat: drop the system-prompt include
-        Copy-Item (Join-Path $Src 'config.md') (Join-Path $TargetDir '.openclaw-system.md') -Force
-        Write-Host "  + .openclaw-system.md (system-prompt include; backward compat)"
-
-        # 2. OpenClaw auto-injects AGENTS.md from the workspace root.
-        #    Safely handle an existing AGENTS.md (codex/aider/cline also use it).
-        $ocAgentsPath = Join-Path $TargetDir 'AGENTS.md'
-        $ocTemplate = Join-Path $Src 'AGENTS.md'
-        if (Test-Path $ocAgentsPath -PathType Leaf) {
-            $ocExisting = Get-Content -Path $ocAgentsPath -Raw -ErrorAction SilentlyContinue
-            if ($ocExisting -match '\.agent/') {
-                Write-Host "  ~ AGENTS.md already references .agent/ — leaving alone"
-            } else {
-                Write-Host "  ! AGENTS.md exists but does not reference .agent/; not overwriting."
-                Write-Host "    merge this block into your AGENTS.md to wire the brain:"
-                Write-Host "    ---8<---"
-                Get-Content -Path $ocTemplate | ForEach-Object { Write-Host "    $_" }
-                Write-Host "    --->8---"
-            }
-        } else {
-            Copy-Item $ocTemplate $ocAgentsPath -Force
-            Write-Host "  + AGENTS.md (auto-injected by OpenClaw from the workspace root)"
-        }
-
-        # 3. Register a project-scoped OpenClaw agent so its workspace == this project.
-        $ocAbs = (Resolve-Path $TargetDir).Path
-        $ocBnRaw = Split-Path -Leaf $ocAbs
-        # lowercase first (OpenClaw normalizes agent ids to lowercase), then sanitize
-        $ocBnSafe = ($ocBnRaw.ToLower() -replace '[^a-z0-9._-]', '-') -replace '-+', '-'
-        $ocBnSafe = $ocBnSafe.Trim('-')
-        if ([string]::IsNullOrEmpty($ocBnSafe)) { $ocBnSafe = 'project' }
-        # 6-hex-char SHA1 suffix of the absolute path for cross-project uniqueness
-        $ocSha = [System.Security.Cryptography.SHA1]::Create()
-        $ocBytes = [System.Text.Encoding]::UTF8.GetBytes($ocAbs)
-        $ocHashHex = -join (($ocSha.ComputeHash($ocBytes)) | ForEach-Object { $_.ToString('x2') })
-        $ocAgentName = "$ocBnSafe-$($ocHashHex.Substring(0,6))"
-
-        $ocBin = Get-Command openclaw -ErrorAction SilentlyContinue
-        if ($ocBin) {
-            Write-Host "  → registering OpenClaw agent '$ocAgentName' (workspace: $ocAbs)"
-            try {
-                $ocOut = & openclaw agents add $ocAgentName --workspace $ocAbs 2>&1
-                $ocRc = $LASTEXITCODE
-                $ocOut | ForEach-Object { Write-Host "    $_" }
-                $ocOutJoined = ($ocOut | Out-String)
-                if ($ocRc -eq 0) {
-                    Write-Host "  ✓ registered. run from anywhere: openclaw --agent $ocAgentName"
-                } elseif ($ocOutJoined -match '(?i)already exists') {
-                    Write-Host "  ✓ already registered (idempotent re-run). run: openclaw --agent $ocAgentName"
-                } else {
-                    Write-Host "  ! 'openclaw agents add' failed (details above)."
-                    Write-Host "    if your OpenClaw fork does not support 'agents add --workspace',"
-                    Write-Host "    fall back to the system-prompt include we wrote:"
-                    Write-Host "      openclaw --system-prompt-file `"$ocAbs\.openclaw-system.md`""
-                    Write-Host "    otherwise retry: openclaw agents add `"$ocAgentName`" --workspace `"$ocAbs`""
-                }
-            } catch {
-                Write-Host "  ! 'openclaw agents add' errored: $_"
-                Write-Host "    fall back to the system-prompt include:"
-                Write-Host "      openclaw --system-prompt-file `"$ocAbs\.openclaw-system.md`""
-                Write-Host "    or retry: openclaw agents add `"$ocAgentName`" --workspace `"$ocAbs`""
-            }
-        } else {
-            Write-Host "  ! 'openclaw' CLI not found on PATH. after installing OpenClaw, try:"
-            Write-Host "      openclaw agents add `"$ocAgentName`" --workspace `"$ocAbs`""
-            Write-Host "      openclaw --agent $ocAgentName"
-            Write-Host "    or, on forks without 'agents add', use the system-prompt include:"
-            Write-Host "      openclaw --system-prompt-file `"$ocAbs\.openclaw-system.md`""
-        }
-    }
-    'hermes' {
-        Copy-Item (Join-Path $Src 'AGENTS.md') (Join-Path $TargetDir 'AGENTS.md') -Force
-    }
-    'pi' {
-        $agentsMd = Join-Path $TargetDir 'AGENTS.md'
-        if (Test-Path $agentsMd -PathType Leaf) {
-            Write-Host "  ~ $agentsMd already exists — skipping (pi reads whatever is there)"
-        } else {
-            Copy-Item (Join-Path $Src 'AGENTS.md') $agentsMd -Force
-            Write-Host "  + AGENTS.md"
-        }
-
-        $piDir = Join-Path $TargetDir '.pi'
-        New-Item -ItemType Directory -Path $piDir -Force | Out-Null
-
-        $skillsSrc = Join-Path $TargetAgent 'skills'
-        $skillsDst = Join-Path $piDir 'skills'
-
-        # CRITICAL: detect symlink BEFORE Remove-Item. On PowerShell 5.1
-        # (Windows default), `Remove-Item -Recurse -Force` on a symlink
-        # traverses INTO the target and deletes its contents. Re-running
-        # the installer would silently wipe .agent/skills via the link.
-        # Use IsLink detection + .NET Delete (link only, not target).
-        $skillsDstItem = Get-Item -LiteralPath $skillsDst -Force -ErrorAction SilentlyContinue
-        if ($skillsDstItem) {
-            $isLink = ($skillsDstItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -eq [System.IO.FileAttributes]::ReparsePoint
-            if ($isLink) {
-                try { [System.IO.Directory]::Delete($skillsDst, $false) }
-                catch { [System.IO.File]::Delete($skillsDst) }
-            } else {
-                Remove-Item -LiteralPath $skillsDst -Recurse -Force
-            }
-        }
-        try {
-            New-Item -ItemType SymbolicLink -Path $skillsDst -Target $skillsSrc -ErrorAction Stop | Out-Null
-            Write-Host "  + .pi/skills -> $skillsSrc"
-        } catch {
-            Copy-Item -Path $skillsSrc -Destination $skillsDst -Recurse
-            Write-Host "  + .pi/skills (copy; symlink not supported here)"
-        }
-
-        $extensionsDir = Join-Path $piDir 'extensions'
-        New-Item -ItemType Directory -Path $extensionsDir -Force | Out-Null
-        Copy-Item (Join-Path $Src 'memory-hook.ts') (Join-Path $extensionsDir 'memory-hook.ts') -Force
-        Write-Host "  + .pi/extensions/memory-hook.ts"
-        # Upgrade path: the .agent copy higher up is skipped when .agent
-        # already exists, but the pi extension calls this python hook,
-        # so sync it explicitly.
-        $hooksDir = Join-Path $TargetAgent 'harness/hooks'
-        New-Item -ItemType Directory -Path $hooksDir -Force | Out-Null
-        Copy-Item (Join-Path $Here '.agent/harness/hooks/pi_post_tool.py') (Join-Path $hooksDir 'pi_post_tool.py') -Force
-        Write-Host "  + .agent/harness/hooks/pi_post_tool.py (synced for upgrades)"
-    }
-    'codex' {
-        # Mirror install.sh: openclaw-style merge-or-alert on existing AGENTS.md.
-        $agentsMd = Join-Path $TargetDir 'AGENTS.md'
-        if (Test-Path $agentsMd -PathType Leaf) {
-            $existing = Get-Content -Path $agentsMd -Raw -ErrorAction SilentlyContinue
-            if ($existing -match '\.agent/') {
-                Write-Host "  ~ AGENTS.md already references .agent/ — leaving alone"
-            } else {
-                Write-Host "  ! AGENTS.md exists but does not reference .agent/; not overwriting."
-                Write-Host "    merge this block into your AGENTS.md to wire the brain:"
-                Write-Host "    ---8<---"
-                Get-Content -Path (Join-Path $Src 'AGENTS.md') | ForEach-Object { Write-Host "    $_" }
-                Write-Host "    --->8---"
-            }
-        } else {
-            Copy-Item (Join-Path $Src 'AGENTS.md') $agentsMd -Force
-            Write-Host "  + AGENTS.md"
-        }
-
-        # Codex scans .agents/skills/ — keep the portable brain authoritative.
-        $agentsDir = Join-Path $TargetDir '.agents'
-        New-Item -ItemType Directory -Path $agentsDir -Force | Out-Null
-        $skillsSrc = Join-Path $TargetAgent 'skills'
-        $skillsDst = Join-Path $agentsDir 'skills'
-
-        # Detect symlink/junction BEFORE Remove-Item: on PowerShell 5.1
-        # `Remove-Item -Recurse` on a symlink can delete the target's
-        # contents. Use IsLink detection + .NET Delete (or repoint).
-        $skillsDstItem = Get-Item -LiteralPath $skillsDst -Force -ErrorAction SilentlyContinue
-        $isLink = $false
-        if ($skillsDstItem) {
-            $isLink = ($skillsDstItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -eq [System.IO.FileAttributes]::ReparsePoint
-        }
-
-        if ($skillsDstItem -and $isLink) {
-            # Existing link: delete the link only (NOT its target), then re-create.
-            try {
-                [System.IO.Directory]::Delete($skillsDst, $false)
-            } catch {
-                [System.IO.File]::Delete($skillsDst)
-            }
-            try {
-                New-Item -ItemType SymbolicLink -Path $skillsDst -Target $skillsSrc -ErrorAction Stop | Out-Null
-                Write-Host "  + .agents/skills -> $skillsSrc (relinked)"
-            } catch {
-                Copy-Item -Path $skillsSrc -Destination $skillsDst -Recurse
-                Write-Host "  + .agents/skills (copy; symlink not supported here)"
-            }
-        } elseif ($skillsDstItem) {
-            Remove-Item -LiteralPath $skillsDst -Recurse -Force
-            try {
-                New-Item -ItemType SymbolicLink -Path $skillsDst -Target $skillsSrc -ErrorAction Stop | Out-Null
-                Write-Host "  + .agents/skills -> $skillsSrc (replaced stale copy)"
-            } catch {
-                Copy-Item -Path $skillsSrc -Destination $skillsDst -Recurse
-                Write-Host "  ~ replaced .agents/skills with current .agent/skills (no symlink)"
-            }
-        } else {
-            try {
-                New-Item -ItemType SymbolicLink -Path $skillsDst -Target $skillsSrc -ErrorAction Stop | Out-Null
-                Write-Host "  + .agents/skills -> $skillsSrc"
-            } catch {
-                Copy-Item -Path $skillsSrc -Destination $skillsDst -Recurse
-                Write-Host "  + .agents/skills (copy; symlink not supported here)"
-            }
-        }
-    }
-    'standalone-python' {
-        Copy-Item (Join-Path $Src 'run.py') (Join-Path $TargetDir 'run.py') -Force
-    }
-    'antigravity' {
-        Copy-Item (Join-Path $Src 'ANTIGRAVITY.md') (Join-Path $TargetDir 'ANTIGRAVITY.md') -Force
-    }
-}
-
-Write-Host "done."
-
-# ── Onboarding wizard ──────────────────────────────────────────────
-$OnboardPy = Join-Path $Here 'onboard.py'
-if (-not (Test-Path $OnboardPy -PathType Leaf)) {
-    Write-Host "tip: customize $TargetDir\.agent\memory\personal\PREFERENCES.md with your conventions."
-    exit 0
-}
-
+# Resolve a python interpreter. Stock Windows ships `python` (not `python3`);
+# Windows-with-WSL or Windows-with-py-launcher might have either. Try in order.
 $python = Get-Command python3 -ErrorAction SilentlyContinue
 if (-not $python) {
     $python = Get-Command python -ErrorAction SilentlyContinue
 }
 if (-not $python) {
-    Write-Host "tip: python3/python not found on PATH — edit .agent\memory\personal\PREFERENCES.md manually."
-    exit 0
+    $python = Get-Command py -ErrorAction SilentlyContinue
+}
+if (-not $python) {
+    Write-Error "python3 or python is required but was not found on PATH. agentic-stack uses python for the installer + brain tooling."
+    exit 1
 }
 
-$wizardArgs = @($OnboardPy, $TargetDir)
-if ($Yes)         { $wizardArgs += '--yes' }
-if ($Reconfigure) { $wizardArgs += '--reconfigure' }
-if ($Force)       { $wizardArgs += '--force' }
+# Build the argv to pass to harness_manager.cli. Preserve the flags that
+# install.sh accepts: --yes, --reconfigure, --force.
+$cliArgs = @()
+if ($Args) { $cliArgs += $Args }
+if ($Yes)         { $cliArgs += '--yes' }
+if ($Reconfigure) { $cliArgs += '--reconfigure' }
+if ($Force)       { $cliArgs += '--force' }
 
-& $python.Source @wizardArgs
+# Hand off. -m runs the module; the dispatcher owns argv parsing.
+& $python.Source -m harness_manager.cli @cliArgs
 exit $LASTEXITCODE

--- a/install.sh
+++ b/install.sh
@@ -1,249 +1,38 @@
 #!/usr/bin/env bash
-# install.sh — copy an adapter into the consuming project, then run the onboarding wizard
-# Usage: ./install.sh <adapter-name> [target-dir] [--yes] [--reconfigure]
-#   adapter-name:  claude-code | cursor | windsurf | opencode | openclaw | hermes | pi | codex | standalone-python | antigravity
-#   target-dir:    where your project lives (default: current dir)
-#   --yes          accept all wizard defaults without prompting (safe for CI)
-#   --reconfigure  re-run the wizard even if PREFERENCES.md is already filled
+# install.sh — agentic-stack installer.
+#
+# Usage:
+#   ./install.sh <adapter-name> [target-dir] [--yes|--reconfigure|--force]
+#                                                # install one adapter
+#   ./install.sh add <adapter-name> [target-dir] # add an adapter to an
+#                                                # already-set-up project
+#   ./install.sh remove <adapter-name> [target-dir] [--yes]
+#                                                # remove an installed adapter
+#   ./install.sh doctor [target-dir]             # read-only audit
+#   ./install.sh status [target-dir]             # one-screen view
+#   ./install.sh                                 # bare: list available adapters
+#                                                # (or, if install.json exists,
+#                                                # show what's installable)
+#
+# adapter-name: claude-code | cursor | windsurf | opencode | openclaw |
+#               hermes | pi | codex | standalone-python | antigravity
+#
+# All real logic lives in harness_manager/ (Python). This script is a
+# thin dispatcher so install.sh and install.ps1 share one backend.
 set -euo pipefail
 
-ADAPTER="${1:-}"
-TARGET="${2:-$PWD}"
 HERE="$(cd "$(dirname "$0")" && pwd)"
+export AGENTIC_STACK_ROOT="$HERE"
+# Prepend HERE so `python3 -m harness_manager.cli` finds the module
+# regardless of which directory the user invoked install.sh from.
+export PYTHONPATH="$HERE${PYTHONPATH:+:$PYTHONPATH}"
 
-if [[ -z "$ADAPTER" ]]; then
-  echo "usage: $0 <adapter-name> [target-dir]" >&2
-  echo "adapters: claude-code cursor windsurf opencode openclaw hermes pi codex standalone-python antigravity" >&2
-  exit 2
-fi
-
-# Collect wizard flags from any position in $@
-WIZARD_FLAGS=""
-for arg in "$@"; do
-  case "$arg" in
-    --yes|-y)        WIZARD_FLAGS="$WIZARD_FLAGS --yes" ;;
-    --reconfigure)   WIZARD_FLAGS="$WIZARD_FLAGS --reconfigure" ;;
-    --force)         WIZARD_FLAGS="$WIZARD_FLAGS --force" ;;
-  esac
-done
-
-SRC="$HERE/adapters/$ADAPTER"
-if [[ ! -d "$SRC" ]]; then
-  echo "error: adapter '$ADAPTER' not found at $SRC" >&2
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "error: python3 is required but not found on PATH." >&2
+  echo "       agentic-stack uses python3 for the installer + brain tooling." >&2
   exit 1
 fi
 
-echo "installing '$ADAPTER' into $TARGET"
-
-# Copy .agent/ brain only if the target does not already have one
-if [[ ! -d "$TARGET/.agent" ]]; then
-  cp -R "$HERE/.agent" "$TARGET/.agent"
-  echo "  + .agent/ (portable brain)"
-fi
-
-case "$ADAPTER" in
-  claude-code)
-    cp "$SRC/CLAUDE.md" "$TARGET/CLAUDE.md"
-    mkdir -p "$TARGET/.claude"
-    cp "$SRC/settings.json" "$TARGET/.claude/settings.json"
-    ;;
-  cursor)
-    mkdir -p "$TARGET/.cursor/rules"
-    cp "$SRC/.cursor/rules/agentic-stack.mdc" "$TARGET/.cursor/rules/agentic-stack.mdc"
-    ;;
-  windsurf)
-    cp "$SRC/.windsurfrules" "$TARGET/.windsurfrules"
-    ;;
-  opencode)
-    cp "$SRC/AGENTS.md" "$TARGET/AGENTS.md"
-    cp "$SRC/opencode.json" "$TARGET/opencode.json"
-    ;;
-  openclaw)
-    # 1. Backward-compat: drop the system-prompt include for users on older
-    #    OpenClaw flows that require pasting or --system-prompt-file.
-    cp "$SRC/config.md" "$TARGET/.openclaw-system.md"
-    echo "  + .openclaw-system.md (system-prompt include; backward compat)"
-
-    # 2. OpenClaw auto-injects AGENTS.md from the workspace root. Drop it
-    #    safely, the same way pi does — don't stomp an existing AGENTS.md
-    #    (codex/aider/amp/cline all use this filename).
-    if [[ -f "$TARGET/AGENTS.md" ]]; then
-      if grep -q '\.agent/' "$TARGET/AGENTS.md" 2>/dev/null; then
-        echo "  ~ AGENTS.md already references .agent/ — leaving alone"
-      else
-        echo "  ! AGENTS.md exists but does not reference .agent/; not overwriting."
-        echo "    merge this block into your AGENTS.md to wire the brain:"
-        echo "    ---8<---"
-        sed 's/^/    /' "$SRC/AGENTS.md"
-        echo "    --->8---"
-      fi
-    else
-      cp "$SRC/AGENTS.md" "$TARGET/AGENTS.md"
-      echo "  + AGENTS.md (auto-injected by OpenClaw from the workspace root)"
-    fi
-
-    # 3. Register a project-scoped OpenClaw agent whose workspace IS this
-    #    project. Without this, OpenClaw's workspace defaults to
-    #    ~/.openclaw/workspace and never sees the .agent/ brain.
-    OC_ABS="$(cd "$TARGET" && pwd)"
-    OC_BN_RAW="$(basename "$OC_ABS")"
-    # lowercase first (OpenClaw normalizes agent ids to lowercase), then
-    # sanitize to [a-z0-9._-], collapse dashes, trim
-    OC_BN_SAFE="$(printf '%s' "$OC_BN_RAW" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9._-' '-' | sed 's/-\{2,\}/-/g; s/^-//; s/-$//')"
-    [[ -z "$OC_BN_SAFE" ]] && OC_BN_SAFE="project"
-    # 6-digit stable suffix from absolute path so cross-project collisions
-    # (api, backend, app, website) resolve to distinct agent names
-    OC_PATH_CKSUM="$(printf '%s' "$OC_ABS" | cksum | awk '{print $1}')"
-    OC_AGENT_NAME="${OC_BN_SAFE}-$(printf '%06d' "$((OC_PATH_CKSUM % 1000000))")"
-
-    if command -v openclaw >/dev/null 2>&1; then
-      echo "  → registering OpenClaw agent '$OC_AGENT_NAME' (workspace: $OC_ABS)"
-      # capture stdout+stderr and rc without tripping set -e
-      OC_RC=0
-      OC_OUT="$(openclaw agents add "$OC_AGENT_NAME" --workspace "$OC_ABS" 2>&1)" || OC_RC=$?
-      printf '%s\n' "$OC_OUT" | sed 's/^/    /'
-      if [[ $OC_RC -eq 0 ]]; then
-        echo "  ✓ registered. run from anywhere: openclaw --agent $OC_AGENT_NAME"
-      elif printf '%s' "$OC_OUT" | grep -qi "already exists"; then
-        echo "  ✓ already registered (idempotent re-run). run: openclaw --agent $OC_AGENT_NAME"
-      else
-        echo "  ! 'openclaw agents add' failed (details above)."
-        echo "    if your OpenClaw fork does not support 'agents add --workspace',"
-        echo "    fall back to the system-prompt include we wrote:"
-        echo "      openclaw --system-prompt-file \"$OC_ABS/.openclaw-system.md\""
-        echo "    otherwise retry: openclaw agents add \"$OC_AGENT_NAME\" --workspace \"$OC_ABS\""
-      fi
-    else
-      echo "  ! 'openclaw' CLI not found on PATH. after installing OpenClaw, try:"
-      echo "      openclaw agents add \"$OC_AGENT_NAME\" --workspace \"$OC_ABS\""
-      echo "      openclaw --agent $OC_AGENT_NAME"
-      echo "    or, on forks without 'agents add', use the system-prompt include:"
-      echo "      openclaw --system-prompt-file \"$OC_ABS/.openclaw-system.md\""
-    fi
-    ;;
-  hermes)
-    cp "$SRC/AGENTS.md" "$TARGET/AGENTS.md"
-    ;;
-  pi)
-    # pi, hermes, and opencode all read AGENTS.md — don't stomp an existing one
-    if [[ -f "$TARGET/AGENTS.md" ]]; then
-      echo "  ~ $TARGET/AGENTS.md already exists — skipping (pi reads whatever is there)"
-    else
-      cp "$SRC/AGENTS.md" "$TARGET/AGENTS.md"
-      echo "  + AGENTS.md"
-    fi
-    mkdir -p "$TARGET/.pi"
-    # Keep .pi/skills in sync with .agent/skills (the one true skill tree).
-    # Handle three shapes explicitly: `ln -sfn src dest` against a REAL
-    # directory silently creates `dest/<basename-of-src>` INSIDE the dir
-    # on macOS/Linux and exits 0, which would leave stale orphans forever.
-    # Check -L before -d so existing symlinks take the cheap repoint path,
-    # and reserve the rsync path for real dirs left from a prior copy
-    # fallback install.
-    SKILLS_SRC="$(cd "$TARGET/.agent/skills" && pwd)"
-    SKILLS_DEST="$TARGET/.pi/skills"
-    if [[ -L "$SKILLS_DEST" ]]; then
-      ln -sfn "$SKILLS_SRC" "$SKILLS_DEST"
-      echo "  + .pi/skills -> $SKILLS_SRC"
-    elif [[ -d "$SKILLS_DEST" ]]; then
-      if command -v rsync >/dev/null 2>&1; then
-        rsync -a --delete "$SKILLS_SRC/" "$SKILLS_DEST/"
-        echo "  ~ synced .agent/skills → .pi/skills (rsync --delete)"
-      else
-        rm -rf "$SKILLS_DEST"
-        cp -R "$SKILLS_SRC" "$SKILLS_DEST"
-        echo "  ~ replaced .pi/skills with current .agent/skills (no rsync)"
-      fi
-    elif ln -sfn "$SKILLS_SRC" "$SKILLS_DEST" 2>/dev/null; then
-      echo "  + .pi/skills -> $SKILLS_SRC"
-    else
-      cp -R "$SKILLS_SRC" "$SKILLS_DEST"
-      echo "  + .pi/skills (copy; symlink not supported here)"
-    fi
-    mkdir -p "$TARGET/.pi/extensions"
-    cp "$SRC/memory-hook.ts" "$TARGET/.pi/extensions/memory-hook.ts"
-    echo "  + .pi/extensions/memory-hook.ts"
-    # Upgrade path: the top-level `.agent/` copy at line 39-42 is skipped
-    # when .agent already exists, but the pi extension calls this python
-    # hook, so sync it explicitly for installs on older agentic-stack
-    # projects that don't already have it.
-    mkdir -p "$TARGET/.agent/harness/hooks"
-    cp "$HERE/.agent/harness/hooks/pi_post_tool.py" "$TARGET/.agent/harness/hooks/pi_post_tool.py"
-    echo "  + .agent/harness/hooks/pi_post_tool.py (synced for upgrades)"
-    ;;
-  codex)
-    # codex reads AGENTS.md (like pi, hermes, opencode). Many other tools
-    # also write AGENTS.md (aider, amp, cline, existing codex setups), so
-    # we follow the openclaw pattern: merge-or-alert, never blind overwrite,
-    # never blind skip.
-    if [[ -f "$TARGET/AGENTS.md" ]]; then
-      if grep -q '\.agent/' "$TARGET/AGENTS.md" 2>/dev/null; then
-        echo "  ~ AGENTS.md already references .agent/ — leaving alone"
-      else
-        echo "  ! AGENTS.md exists but does not reference .agent/; not overwriting."
-        echo "    merge this block into your AGENTS.md to wire the brain:"
-        echo "    ---8<---"
-        sed 's/^/    /' "$SRC/AGENTS.md"
-        echo "    --->8---"
-      fi
-    else
-      cp "$SRC/AGENTS.md" "$TARGET/AGENTS.md"
-      echo "  + AGENTS.md"
-    fi
-
-    # Codex scans .agents/skills/ (plural) for repo-scoped skills — per
-    # OpenAI docs https://developers.openai.com/codex/skills. Keep the
-    # portable brain authoritative: .agents/skills mirrors .agent/skills.
-    mkdir -p "$TARGET/.agents"
-    SKILLS_SRC="$(cd "$TARGET/.agent/skills" && pwd)"
-    SKILLS_DEST="$TARGET/.agents/skills"
-    if [[ -L "$SKILLS_DEST" ]]; then
-      # Existing symlink: repoint at current .agent/skills (cheap, safe)
-      ln -sfn "$SKILLS_SRC" "$SKILLS_DEST"
-      echo "  + .agents/skills -> $SKILLS_SRC"
-    elif [[ -d "$SKILLS_DEST" ]]; then
-      # Real directory from a prior copy-fallback install: sync with
-      # delete-orphans so removed/renamed skills don't linger. Use rsync
-      # if available, otherwise rm+cp as a safe-but-blunt replacement.
-      if command -v rsync >/dev/null 2>&1; then
-        rsync -a --delete "$SKILLS_SRC/" "$SKILLS_DEST/"
-        echo "  ~ synced .agent/skills → .agents/skills (rsync --delete)"
-      else
-        rm -rf "$SKILLS_DEST"
-        cp -R "$SKILLS_SRC" "$SKILLS_DEST"
-        echo "  ~ replaced .agents/skills with current .agent/skills (no rsync)"
-      fi
-    elif ln -sfn "$SKILLS_SRC" "$SKILLS_DEST" 2>/dev/null; then
-      echo "  + .agents/skills -> $SKILLS_SRC"
-    else
-      cp -R "$SKILLS_SRC" "$SKILLS_DEST"
-      echo "  + .agents/skills (copy; symlink not supported here)"
-    fi
-    ;;
-  standalone-python)
-    cp "$SRC/run.py" "$TARGET/run.py"
-    ;;
-  antigravity)
-    cp "$SRC/ANTIGRAVITY.md" "$TARGET/ANTIGRAVITY.md"
-    ;;
-  *)
-    echo "error: unknown adapter '$ADAPTER'" >&2
-    exit 1
-    ;;
-esac
-
-echo "done."
-
-# ── Onboarding wizard ──────────────────────────────────────────────────────
-ONBOARD_PY="$HERE/onboard.py"
-if [[ ! -f "$ONBOARD_PY" ]]; then
-  echo "tip: customize $TARGET/$( echo '.agent/memory/personal/PREFERENCES.md' ) with your conventions."
-  exit 0
-fi
-if ! command -v python3 &>/dev/null; then
-  echo "tip: python3 not found — edit .agent/memory/personal/PREFERENCES.md manually."
-  exit 0
-fi
-
-# exec replaces this shell; no return needed
-exec python3 "$ONBOARD_PY" "$TARGET" $WIZARD_FLAGS
+# Hand off to the Python dispatcher. It owns argv parsing, verb routing,
+# adapter validation, and onboarding flow.
+exec python3 -m harness_manager.cli "$@"

--- a/onboard_widgets.py
+++ b/onboard_widgets.py
@@ -67,6 +67,76 @@ def ask_select(label, choices, default=0):
     return choices[sel]
 
 
+def ask_multiselect(label, choices, defaults=None, hint_extra=""):
+    """Arrow-key multi-select with space-toggle. Returns list of chosen strings.
+
+    `choices`: list of strings.
+    `defaults`: list of indices to start checked (default: none).
+    `hint_extra`: extra hint string appended to the navigation help.
+
+    Same posture as ask_select: clack ◇ label, BAR rail, ▮ summary.
+    Glyphs: ◉ checked / ○ unchecked, ▸ cursor.
+    Keys: ↑↓ navigate · space toggle · enter confirm · q cancel (returns []).
+
+    NOTE: uses `q` (not ESC) to cancel because the existing POSIX get_key()
+    blocks on lone ESC waiting for an arrow-key sequence's second byte.
+    `q` is universally available, no platform-specific terminal dance.
+    """
+    sel = set(defaults or [])
+    cur = 0
+
+    def _render():
+        for i, c in enumerate(choices):
+            box = f"{GREEN}◉{R}" if i in sel else f"{MUTED}○{R}"
+            arrow = f"{BLUE}▸{R}" if i == cur else " "
+            label_color = f"{WHITE}{B}" if i == cur else MUTED
+            print(f"{BAR}  {arrow} {box}  {label_color}{c}{R}")
+        print(f"{MUTED}└{R}")
+
+    hint = f"  {MUTED}↑↓ navigate  ·  space toggle  ·  enter confirm  ·  q cancel{hint_extra}{R}"
+    print(f"{PURPLE}◇{R}  {B}{WHITE}{label}{R}{hint}")
+    _render()
+
+    sys.stdout.write(HIDE)
+    sys.stdout.flush()
+    n = len(choices)
+    cancelled = False
+    try:
+        while True:
+            key = get_key()
+            if   key == "UP":    cur = (cur - 1) % n
+            elif key == "DOWN":  cur = (cur + 1) % n
+            elif key == " ":     # literal space toggles current row
+                if cur in sel: sel.remove(cur)
+                else:          sel.add(cur)
+            elif key == "ENTER": break
+            elif key == "q" or key == "Q":
+                cancelled = True
+                break
+            else:
+                continue
+            for _ in range(n + 1):
+                sys.stdout.write(UP + CLR)
+            sys.stdout.flush()
+            _render()
+    finally:
+        sys.stdout.write(SHOW)
+        sys.stdout.flush()
+
+    for _ in range(n + 2):
+        sys.stdout.write(UP + CLR)
+    sys.stdout.flush()
+
+    if cancelled:
+        step_done(label, "(cancelled)")
+        return []
+
+    chosen = [choices[i] for i in sorted(sel)]
+    summary = ", ".join(chosen) if chosen else "(none)"
+    step_done(label, summary)
+    return chosen
+
+
 def ask_confirm(label, default=True):
     """Y / n confirm. Returns bool."""
     hint = f"{'Y/n' if default else 'y/N'}"

--- a/tests/test_adapter_manifests.py
+++ b/tests/test_adapter_manifests.py
@@ -1,0 +1,168 @@
+"""Validate every adapters/<name>/adapter.json against the schema.
+
+Run: python3 -m unittest tests.test_adapter_manifests
+Or:  python3 tests/test_adapter_manifests.py
+"""
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from harness_manager.schema import (  # noqa: E402
+    ManifestError,
+    discover_all,
+    validate_dict,
+)
+
+
+class TestSchemaValidation(unittest.TestCase):
+    """Programmatic checks: handcrafted good and bad manifests."""
+
+    def _good_minimal(self) -> dict:
+        return {
+            "name": "minimal",
+            "description": "minimal adapter for testing",
+            "files": [
+                {"src": "AGENTS.md", "dst": "AGENTS.md"}
+            ],
+        }
+
+    def test_minimal_manifest_validates(self):
+        m = self._good_minimal()
+        self.assertEqual(validate_dict(m, "test"), m)
+
+    def test_full_manifest_validates(self):
+        m = {
+            "name": "claude-code",
+            "description": "Claude Code with hooks",
+            "brain_root_primitive": "$CLAUDE_PROJECT_DIR",
+            "files": [
+                {
+                    "src": "settings.json",
+                    "dst": ".claude/settings.json",
+                    "merge_policy": "overwrite",
+                    "substitute": True,
+                },
+                {
+                    "src": "CLAUDE.md",
+                    "dst": "CLAUDE.md",
+                    "merge_policy": "overwrite",
+                },
+            ],
+            "skills_link": {
+                "target": ".agent/skills",
+                "dst": ".pi/skills",
+                "fallback": "rsync_with_delete",
+            },
+            "post_install": ["openclaw_register_workspace"],
+        }
+        self.assertEqual(validate_dict(m, "test")["name"], "claude-code")
+
+    def test_from_stack_field_accepted(self):
+        m = self._good_minimal()
+        m["files"][0]["from_stack"] = True
+        validate_dict(m, "test")
+
+    def test_missing_required_name(self):
+        m = self._good_minimal()
+        del m["name"]
+        with self.assertRaises(ManifestError) as ctx:
+            validate_dict(m, "test")
+        self.assertIn("missing required field 'name'", str(ctx.exception))
+
+    def test_missing_required_files(self):
+        m = self._good_minimal()
+        del m["files"]
+        with self.assertRaises(ManifestError) as ctx:
+            validate_dict(m, "test")
+        self.assertIn("missing required field 'files'", str(ctx.exception))
+
+    def test_empty_files_list_rejected(self):
+        m = self._good_minimal()
+        m["files"] = []
+        with self.assertRaises(ManifestError) as ctx:
+            validate_dict(m, "test")
+        self.assertIn("at least one entry", str(ctx.exception))
+
+    def test_path_traversal_rejected(self):
+        m = self._good_minimal()
+        m["files"][0]["src"] = "../etc/passwd"
+        with self.assertRaises(ManifestError) as ctx:
+            validate_dict(m, "test")
+        self.assertIn("'..' path components not allowed", str(ctx.exception))
+
+    def test_absolute_path_rejected(self):
+        m = self._good_minimal()
+        m["files"][0]["dst"] = "/etc/passwd"
+        with self.assertRaises(ManifestError) as ctx:
+            validate_dict(m, "test")
+        self.assertIn("absolute paths not allowed", str(ctx.exception))
+
+    def test_invalid_merge_policy(self):
+        m = self._good_minimal()
+        m["files"][0]["merge_policy"] = "yolo"
+        with self.assertRaises(ManifestError) as ctx:
+            validate_dict(m, "test")
+        self.assertIn("merge_policy", str(ctx.exception))
+
+    def test_unknown_post_install_action(self):
+        m = self._good_minimal()
+        m["post_install"] = ["wipe_disk"]
+        with self.assertRaises(ManifestError) as ctx:
+            validate_dict(m, "test")
+        self.assertIn("unknown action 'wipe_disk'", str(ctx.exception))
+
+    def test_unknown_top_level_field_rejected(self):
+        m = self._good_minimal()
+        m["secret_handshake"] = True
+        with self.assertRaises(ManifestError) as ctx:
+            validate_dict(m, "test")
+        self.assertIn("unknown top-level field", str(ctx.exception))
+
+    def test_brain_root_primitive_must_start_with_dollar(self):
+        m = self._good_minimal()
+        m["brain_root_primitive"] = "CLAUDE_PROJECT_DIR"  # missing $
+        with self.assertRaises(ManifestError) as ctx:
+            validate_dict(m, "test")
+        self.assertIn("must be a shell env var", str(ctx.exception))
+
+    def test_invalid_name_with_spaces(self):
+        m = self._good_minimal()
+        m["name"] = "has spaces"
+        with self.assertRaises(ManifestError) as ctx:
+            validate_dict(m, "test")
+        self.assertIn("alphanumeric", str(ctx.exception))
+
+
+class TestRealAdapterManifests(unittest.TestCase):
+    """Walks adapters/ and validates every adapter.json that exists.
+
+    During the migration window, adapters without adapter.json are
+    silently skipped — discover_all() doesn't require all 10 adapters
+    to be migrated. After full migration, this test will naturally
+    cover all 10.
+    """
+
+    def test_all_present_adapter_jsons_validate(self):
+        manifests = discover_all(REPO_ROOT)
+        # Don't fail if there are zero migrated adapters yet — that's
+        # a valid intermediate state during Step 2 of the implementation.
+        for name, manifest in manifests:
+            self.assertEqual(
+                manifest["name"],
+                name,
+                f"adapter '{name}' has manifest name='{manifest['name']}'; mismatch",
+            )
+
+    def test_discover_returns_sorted(self):
+        manifests = discover_all(REPO_ROOT)
+        names = [n for n, _ in manifests]
+        self.assertEqual(
+            names, sorted(names), "discover_all should return sorted by adapter name"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_install_e2e.py
+++ b/tests/test_install_e2e.py
@@ -307,6 +307,71 @@ class TestEndToEndInstallFlow(unittest.TestCase):
         # Also verify the cksum primitive itself matches POSIX cksum(1).
         self.assertEqual(_posix_cksum(b"/Users/foo/myproject"), 4089408017)
 
+    def test_openclaw_sanitizer_matches_legacy_bash(self):
+        """Codex P2: sanitizer must use ASCII-only [a-z0-9._-] and regex collapse.
+
+        The pre-v0.9.0 bash was:
+          tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9._-' '-' | sed 's/-\\{2,\\}/-/g; s/^-//; s/-$//'
+
+        Edge cases that broke the early Python implementation:
+        - Non-ASCII letters (str.isalnum() preserves them; tr does not)
+        - Runs of dashes (str.replace("--","-") is single-pass; sed regex collapses fully)
+        """
+        from harness_manager.post_install import _openclaw_agent_name
+        # Hand-derived expectations, lowercased basename + cksum-based suffix.
+        # We only assert the basename portion (suffix is path-dependent).
+        # Non-ASCII test: "café" → bash would have produced "caf-" (ç → -)
+        # and the sanitizer would strip the trailing dash → "caf".
+        name = _openclaw_agent_name("/tmp/café")
+        self.assertTrue(
+            name.startswith("caf-"),
+            f"non-ASCII char ç should sanitize to '-' (then stripped or kept), "
+            f"got name '{name}'",
+        )
+        self.assertNotIn("é", name)  # accents must be gone, not preserved
+        # Run-of-dashes test: "a----b" basename
+        name = _openclaw_agent_name("/tmp/a----b")
+        self.assertTrue(
+            name.startswith("a-b-"),
+            f"runs of dashes should collapse to single '-', got name '{name}'",
+        )
+
+    def test_doctor_yellow_when_openclaw_register_was_skipped(self):
+        """Codex P1: doctor must NOT report red for adapters whose register
+        post_install was binary_missing at install time. The fallback hint
+        is the documented behavior, not a bug.
+        """
+        # Install openclaw — but openclaw binary is not in PATH on this box,
+        # so post_install will record status: binary_missing.
+        # (We rely on the test environment NOT having openclaw on PATH,
+        # OR the install simulating it — for this assertion, we just check
+        # that whatever status was recorded, doctor handles all branches
+        # correctly.)
+        self._install("openclaw")
+        doc = state_mod.load(self.target)
+        entry = doc["adapters"]["openclaw"]
+        results = entry.get("post_install_results", [])
+        if not results:
+            self.skipTest("openclaw didn't record post_install_results — skip")
+        register = next(
+            (r for r in results if r.get("action") == "openclaw_register_workspace"),
+            None,
+        )
+        if register is None or register.get("status") in ("ok", "already_exists"):
+            self.skipTest("openclaw was actually registered ok — different code path")
+        # Status is binary_missing or failed. Doctor must NOT mark red just
+        # because the agent isn't in ~/.openclaw/openclaw.json — the install
+        # never registered it, so absence is expected.
+        log_lines = []
+        rc = doctor_mod.audit(self.target, log=log_lines.append)
+        all_text = "\n".join(log_lines)
+        # Yellow allowed (rc=0), red is the bug we're guarding against.
+        self.assertEqual(
+            rc, 0,
+            f"doctor should not return red when openclaw registration was "
+            f"skipped at install time. log:\n{all_text}",
+        )
+
     def test_state_lock_prevents_lost_update(self):
         """Codex P2: concurrent upsert_adapter must not lose entries.
 

--- a/tests/test_install_e2e.py
+++ b/tests/test_install_e2e.py
@@ -450,6 +450,111 @@ class TestEndToEndInstallFlow(unittest.TestCase):
         finally:
             pi_mod.reverse = original_reverse
 
+    def test_remove_preserves_pre_existing_skills_link_dir(self):
+        """Codex P1: if user already had .agents/skills/ before installing
+        codex, remove must NOT delete it (we adopted, didn't create).
+        """
+        # Plant a pre-existing user-owned .agents/skills directory with
+        # custom content.
+        user_skills = self.target / ".agents" / "skills"
+        user_skills.mkdir(parents=True, exist_ok=True)
+        (user_skills / "user-skill").mkdir()
+        (user_skills / "user-skill" / "SKILL.md").write_text(
+            "---\nname: user-skill\ndescription: my own\n---\n", encoding="utf-8"
+        )
+
+        # Install codex — adopts the existing dir via rsync.
+        self._install("codex")
+        doc = state_mod.load(self.target)
+        entry = doc["adapters"]["codex"]
+        self.assertTrue(
+            entry.get("skills_link_pre_existed"),
+            "skills_link_pre_existed should be True when target dir was present pre-install",
+        )
+
+        # Remove codex. The skills_link dst should NOT be deleted.
+        rc = remove_mod.remove(self.target, "codex", yes=True, log=lambda _: None)
+        self.assertEqual(rc, 0)
+        self.assertTrue(
+            user_skills.exists(),
+            "remove deleted .agents/skills/ which pre-existed install — destroys user data",
+        )
+
+    def test_remove_deletes_installer_created_skills_link(self):
+        """Sanity check: when WE created the skills_link, remove DOES delete it."""
+        # Fresh project, no pre-existing .agents/skills.
+        self._install("codex")
+        doc = state_mod.load(self.target)
+        entry = doc["adapters"]["codex"]
+        self.assertFalse(
+            entry.get("skills_link_pre_existed", False),
+            "skills_link_pre_existed should be False on fresh install",
+        )
+        rc = remove_mod.remove(self.target, "codex", yes=True, log=lambda _: None)
+        self.assertEqual(rc, 0)
+        skills_dst = self.target / ".agents" / "skills"
+        self.assertFalse(
+            skills_dst.exists() and not skills_dst.is_symlink(),
+            "remove failed to clean up installer-created skills_link",
+        )
+
+    def test_openclaw_reverse_uses_stored_agent_name_not_recompute(self):
+        """Codex P2: openclaw reverse must use the agent_name recorded at
+        install time, not recompute from current target_root. Otherwise a
+        renamed/moved project tries to remove the wrong agent and orphans
+        the original.
+        """
+        from harness_manager import post_install as pi_mod
+        # Plant an install.json with a synthetic openclaw entry whose
+        # recorded agent_name does NOT match what _openclaw_agent_name
+        # would compute now (simulates: project was renamed after install).
+        recorded_name = "old-name-123456"
+        state_mod.upsert_adapter(
+            self.target,
+            "openclaw",
+            {
+                "installed_at": "x",
+                "files_written": [],
+                "files_overwritten": [],
+                "files_alerted": [],
+                "file_results": [],
+                "post_install_results": [
+                    {
+                        "action": "openclaw_register_workspace",
+                        "status": "ok",
+                        "agent_name": recorded_name,
+                    }
+                ],
+            },
+            "0.9.0",
+        )
+
+        # Spy on what name reverse() actually receives.
+        seen = {"agent_name": None}
+        original = pi_mod.openclaw_unregister_workspace
+        def _spy(target_root, **kwargs):
+            seen["agent_name"] = kwargs.get("agent_name") or pi_mod._openclaw_agent_name(target_root)
+            # Don't actually invoke openclaw — just record what would be called.
+            return {"action": "openclaw_unregister_workspace", "status": "ok",
+                    "agent_name": seen["agent_name"]}
+        pi_mod.ACTIONS["openclaw_register_workspace"] = (
+            pi_mod.openclaw_register_workspace, _spy
+        )
+        try:
+            rc = remove_mod.remove(self.target, "openclaw", yes=True, log=lambda _: None)
+            self.assertEqual(rc, 0)
+            self.assertEqual(
+                seen["agent_name"],
+                recorded_name,
+                f"remove called openclaw unregister with '{seen['agent_name']}' "
+                f"but install.json recorded '{recorded_name}'. A renamed project "
+                f"would orphan the original openclaw agent.",
+            )
+        finally:
+            pi_mod.ACTIONS["openclaw_register_workspace"] = (
+                pi_mod.openclaw_register_workspace, original
+            )
+
     def test_state_lock_prevents_lost_update(self):
         """Codex P2: concurrent upsert_adapter must not lose entries.
 

--- a/tests/test_install_e2e.py
+++ b/tests/test_install_e2e.py
@@ -555,6 +555,113 @@ class TestEndToEndInstallFlow(unittest.TestCase):
                 pi_mod.openclaw_register_workspace, original
             )
 
+    def test_doctor_synthesis_populates_files_written(self):
+        """Codex P1: doctor's first-run synthesis on a pre-v0.9 project must
+        seed files_written from the adapter manifest, otherwise:
+          - remove becomes a no-op (files stay on disk forever)
+          - subsequent add reclassifies our own files as user-owned
+        """
+        # Simulate a pre-v0.9 install: drop the files the old install.sh
+        # would have written, but no install.json.
+        (self.target / ".cursor" / "rules").mkdir(parents=True)
+        (self.target / ".cursor" / "rules" / "agentic-stack.mdc").write_text("rules", encoding="utf-8")
+        (self.target / ".agent").mkdir()
+        (self.target / ".agent" / "AGENTS.md").write_text("brain", encoding="utf-8")
+
+        self.assertIsNone(state_mod.load(self.target), "no install.json yet")
+
+        # Synthesize via doctor's pre-v0.9 path. We bypass the input() prompt
+        # by calling _audit_pre_v090 directly with stdin not-a-tty (the
+        # function honors that — but we need to sim the Y answer). Easier:
+        # invoke through a monkey-patched input.
+        import builtins
+        from unittest.mock import patch
+        orig_input = builtins.input
+        builtins.input = lambda *a, **kw: "y"
+        try:
+            with patch("sys.stdin.isatty", return_value=True):
+                rc = doctor_mod.audit(self.target, log=lambda _: None)
+        finally:
+            builtins.input = orig_input
+        self.assertEqual(rc, 0)
+
+        doc = state_mod.load(self.target)
+        self.assertIsNotNone(doc, "doctor failed to synthesize install.json")
+        self.assertIn("cursor", doc["adapters"])
+        cursor_entry = doc["adapters"]["cursor"]
+        self.assertIn(
+            ".cursor/rules/agentic-stack.mdc",
+            cursor_entry["files_written"],
+            "synthesis must populate files_written so remove can clean up "
+            "pre-v0.9 install artifacts",
+        )
+        self.assertTrue(cursor_entry.get("_synthesized"))
+
+    def test_doctor_synthesis_skips_merge_or_alert_files(self):
+        """Synthesis must NOT claim ownership of merge_or_alert files
+        (e.g., AGENTS.md) — those may be user-owned content that the old
+        install.sh deliberately preserved.
+        """
+        # Pre-v0.9 codex install: AGENTS.md exists (was the user's own file
+        # the old install.sh skipped); .agents/skills exists (old install.sh
+        # always created this).
+        self.target.mkdir(parents=True, exist_ok=True)
+        (self.target / "AGENTS.md").write_text("user's own AGENTS.md", encoding="utf-8")
+        (self.target / ".agents" / "skills").mkdir(parents=True)
+        (self.target / ".agent").mkdir(exist_ok=True)
+        (self.target / ".agent" / "AGENTS.md").write_text("brain", encoding="utf-8")
+
+        import builtins
+        from unittest.mock import patch
+        orig_input = builtins.input
+        builtins.input = lambda *a, **kw: "y"
+        try:
+            with patch("sys.stdin.isatty", return_value=True):
+                rc = doctor_mod.audit(self.target, log=lambda _: None)
+        finally:
+            builtins.input = orig_input
+        self.assertEqual(rc, 0)
+
+        doc = state_mod.load(self.target)
+        codex_entry = doc["adapters"].get("codex")
+        if codex_entry is None:
+            self.skipTest("detection didn't pick up codex from .agents/skills alone")
+        # AGENTS.md is merge_or_alert in codex's manifest → must be in
+        # files_alerted, NOT files_written. Otherwise remove would delete
+        # the user's AGENTS.md.
+        self.assertNotIn("AGENTS.md", codex_entry["files_written"])
+        # And the skills_link should be claimed (old install.sh always
+        # created it).
+        self.assertIn("skills_link", codex_entry)
+
+    def test_openclaw_agent_name_platform_specific(self):
+        """Codex P2: openclaw agent name uses cksum on POSIX, SHA1 on Windows.
+
+        Both legacy install scripts (install.sh + install.ps1) used
+        different hash functions; we must match each per-platform to keep
+        upgrade installs from registering a second agent.
+        """
+        from harness_manager.post_install import _openclaw_agent_name
+        import platform as _plat
+
+        name = _openclaw_agent_name("/Users/foo/myproject")
+        if _plat.system() == "Windows":
+            # SHA1[:6] hex
+            self.assertRegex(
+                name,
+                r"^myproject-[0-9a-f]{6}$",
+                f"on Windows, agent name suffix should be 6 hex chars (SHA1[:6]), got '{name}'",
+            )
+        else:
+            # cksum mod 1_000_000, zero-padded 6 decimal digits
+            self.assertRegex(
+                name,
+                r"^myproject-\d{6}$",
+                f"on POSIX, agent name suffix should be 6 decimal digits (cksum), got '{name}'",
+            )
+            # Hand-verified pre-v0.9 install.sh value
+            self.assertEqual(name, "myproject-408017")
+
     def test_state_lock_prevents_lost_update(self):
         """Codex P2: concurrent upsert_adapter must not lose entries.
 

--- a/tests/test_install_e2e.py
+++ b/tests/test_install_e2e.py
@@ -1,0 +1,203 @@
+"""End-to-end install + doctor + remove against a temp project.
+
+Specifically verifies the #18 fix: claude-code adapter installs with
+$CLAUDE_PROJECT_DIR substituted into hook command paths, so hooks
+resolve correctly regardless of cwd.
+
+Run: python3 -m unittest tests.test_install_e2e -v
+"""
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from harness_manager import doctor as doctor_mod  # noqa: E402
+from harness_manager import install as install_mod  # noqa: E402
+from harness_manager import remove as remove_mod  # noqa: E402
+from harness_manager import schema as schema_mod  # noqa: E402
+from harness_manager import state as state_mod  # noqa: E402
+
+
+def _adapter_manifest(name: str) -> tuple[dict, Path]:
+    p = REPO_ROOT / "adapters" / name / "adapter.json"
+    return schema_mod.validate(p), p.parent
+
+
+class TestEndToEndInstallFlow(unittest.TestCase):
+    def setUp(self):
+        self.target = Path(tempfile.mkdtemp(prefix="hm-e2e-"))
+        self.target_stack_brain_backup = REPO_ROOT / ".agent" / "memory" / "episodic" / "AGENT_LEARNINGS.jsonl"
+        self._brain_snapshot = self.target_stack_brain_backup.read_bytes() if self.target_stack_brain_backup.is_file() else None
+
+    def tearDown(self):
+        # Revert any episodic logging the install may have triggered against
+        # the source brain.
+        if self._brain_snapshot is not None:
+            self.target_stack_brain_backup.write_bytes(self._brain_snapshot)
+        for cache in [
+            REPO_ROOT / ".agent" / "memory" / "__pycache__",
+            REPO_ROOT / ".agent" / "harness" / "__pycache__",
+            REPO_ROOT / ".agent" / "harness" / "hooks" / "__pycache__",
+            REPO_ROOT / "harness_manager" / "__pycache__",
+            REPO_ROOT / "tests" / "__pycache__",
+        ]:
+            shutil.rmtree(cache, ignore_errors=True)
+        shutil.rmtree(self.target, ignore_errors=True)
+
+    def _install(self, adapter_name: str):
+        manifest, adapter_dir = _adapter_manifest(adapter_name)
+        install_mod.install(
+            manifest=manifest,
+            target_root=self.target,
+            adapter_dir=adapter_dir,
+            stack_root=REPO_ROOT,
+            log=lambda _: None,  # silent in test
+        )
+
+    # ---- #18 regression test ------------------------------------------
+
+    def test_18_claude_code_settings_substitutes_brain_root(self):
+        """The whole point of v0.9.0: cwd-stable hook commands."""
+        self._install("claude-code")
+        settings_path = self.target / ".claude" / "settings.json"
+        self.assertTrue(settings_path.is_file(), "settings.json was not written")
+        content = settings_path.read_text(encoding="utf-8")
+
+        # Placeholder must be gone.
+        self.assertNotIn(
+            "{{BRAIN_ROOT}}",
+            content,
+            "{{BRAIN_ROOT}} placeholder leaked into installed settings.json",
+        )
+        # Actual primitive must be present in both hook commands.
+        self.assertIn(
+            "$CLAUDE_PROJECT_DIR/.agent/harness/hooks/claude_code_post_tool.py",
+            content,
+            "PostToolUse hook missing $CLAUDE_PROJECT_DIR substitution",
+        )
+        self.assertIn(
+            "$CLAUDE_PROJECT_DIR/.agent/memory/auto_dream.py",
+            content,
+            "Stop hook missing $CLAUDE_PROJECT_DIR substitution",
+        )
+        # Relative-path form must NOT be present (the bug).
+        relative_pattern = re.compile(
+            r'"command":\s*"python3 \.agent/'
+        )
+        self.assertIsNone(
+            relative_pattern.search(content),
+            "settings.json still contains the buggy relative-path hook command",
+        )
+
+    # ---- install.json shape -------------------------------------------
+
+    def test_install_json_well_formed(self):
+        self._install("claude-code")
+        doc = state_mod.load(self.target)
+        self.assertIsNotNone(doc)
+        self.assertEqual(doc["schema_version"], 1)
+        self.assertIn("claude-code", doc["adapters"])
+        entry = doc["adapters"]["claude-code"]
+        self.assertEqual(
+            sorted(entry["files_written"]),
+            sorted(["CLAUDE.md", ".claude/settings.json"]),
+        )
+        self.assertEqual(entry["brain_root_primitive"], "$CLAUDE_PROJECT_DIR")
+
+    # ---- multi-adapter -----------------------------------------------
+
+    def test_install_three_adapters_independent(self):
+        self._install("cursor")
+        self._install("claude-code")
+        self._install("pi")
+        doc = state_mod.load(self.target)
+        self.assertEqual(
+            sorted(doc["adapters"].keys()),
+            sorted(["cursor", "claude-code", "pi"]),
+        )
+        # pi has skills_link
+        self.assertIn("skills_link", doc["adapters"]["pi"])
+        # claude-code has primitive
+        self.assertEqual(
+            doc["adapters"]["claude-code"]["brain_root_primitive"],
+            "$CLAUDE_PROJECT_DIR",
+        )
+        # cursor is simple
+        self.assertEqual(
+            doc["adapters"]["cursor"]["files_written"],
+            [".cursor/rules/agentic-stack.mdc"],
+        )
+
+    # ---- pi skills_link + from_stack ---------------------------------
+
+    def test_pi_install_creates_symlink_and_syncs_hook(self):
+        self._install("pi")
+        # AGENTS.md
+        self.assertTrue((self.target / "AGENTS.md").is_file())
+        # memory-hook.ts (adapter-local file)
+        self.assertTrue((self.target / ".pi" / "extensions" / "memory-hook.ts").is_file())
+        # pi_post_tool.py (from_stack: true — synced from agentic-stack source)
+        self.assertTrue(
+            (self.target / ".agent" / "harness" / "hooks" / "pi_post_tool.py").is_file(),
+            "from_stack file pi_post_tool.py was not synced",
+        )
+        # skills symlink
+        skills_dst = self.target / ".pi" / "skills"
+        self.assertTrue(skills_dst.is_symlink() or skills_dst.is_dir())
+        if skills_dst.is_symlink():
+            self.assertTrue(skills_dst.resolve().is_dir())
+
+    # ---- doctor green path -------------------------------------------
+
+    def test_doctor_all_green_after_fresh_install(self):
+        self._install("cursor")
+        self._install("claude-code")
+        rc = doctor_mod.audit(self.target, log=lambda _: None)
+        self.assertEqual(rc, 0, "doctor returned non-zero on a fresh install")
+
+    # ---- doctor red on missing file ----------------------------------
+
+    def test_doctor_red_when_tracked_file_deleted(self):
+        self._install("cursor")
+        # Delete the file cursor installed
+        (self.target / ".cursor" / "rules" / "agentic-stack.mdc").unlink()
+        rc = doctor_mod.audit(self.target, log=lambda _: None)
+        self.assertEqual(rc, 1, "doctor should return 1 when a tracked file is missing")
+
+    # ---- remove --yes is idempotent and clean ------------------------
+
+    def test_remove_deletes_files_and_updates_install_json(self):
+        self._install("cursor")
+        rc = remove_mod.remove(self.target, "cursor", yes=True, log=lambda _: None)
+        self.assertEqual(rc, 0)
+        self.assertFalse(
+            (self.target / ".cursor" / "rules" / "agentic-stack.mdc").exists()
+        )
+        doc = state_mod.load(self.target)
+        self.assertNotIn("cursor", doc["adapters"])
+
+    def test_remove_unknown_adapter_returns_nonzero(self):
+        # No install.json yet
+        rc = remove_mod.remove(self.target, "cursor", yes=True, log=lambda _: None)
+        self.assertEqual(rc, 1)
+
+    # ---- idempotency -------------------------------------------------
+
+    def test_install_twice_no_dup_state(self):
+        self._install("cursor")
+        self._install("cursor")
+        doc = state_mod.load(self.target)
+        # Single entry, replaced not appended.
+        self.assertEqual(list(doc["adapters"].keys()), ["cursor"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_install_e2e.py
+++ b/tests/test_install_e2e.py
@@ -26,6 +26,14 @@ from harness_manager import schema as schema_mod  # noqa: E402
 from harness_manager import state as state_mod  # noqa: E402
 
 
+def _concurrent_upsert_worker(args):
+    """Module-level worker for the concurrency test (Py3.14 spawn needs picklable)."""
+    target, idx = args
+    sys.path.insert(0, str(REPO_ROOT))
+    from harness_manager import state as st
+    st.upsert_adapter(target, f"a{idx:02d}", {"installed_at": "x"}, "0.9.0")
+
+
 def _adapter_manifest(name: str) -> tuple[dict, Path]:
     p = REPO_ROOT / "adapters" / name / "adapter.json"
     return schema_mod.validate(p), p.parent
@@ -197,6 +205,135 @@ class TestEndToEndInstallFlow(unittest.TestCase):
         doc = state_mod.load(self.target)
         # Single entry, replaced not appended.
         self.assertEqual(list(doc["adapters"].keys()), ["cursor"])
+
+    # ---- regression tests from codex pre-PR review --------------------
+
+    def test_remove_preserves_pre_existing_user_files(self):
+        """Codex P1: files_overwritten must NOT be deleted by remove."""
+        # Simulate a user who already had .claude/settings.json with their
+        # own content — install (overwrite policy) replaces it; remove
+        # MUST NOT delete it (the user's original is gone, but neither
+        # should we delete what we left).
+        custom_settings = self.target / ".claude" / "settings.json"
+        custom_settings.parent.mkdir(parents=True, exist_ok=True)
+        custom_settings.write_text('{"user": "custom"}', encoding="utf-8")
+
+        self._install("claude-code")
+        # claude-code's settings.json has merge_policy: overwrite, so
+        # it replaced the file. Track it as files_overwritten, NOT files_written.
+        doc = state_mod.load(self.target)
+        entry = doc["adapters"]["claude-code"]
+        self.assertIn(".claude/settings.json", entry["files_overwritten"])
+        self.assertNotIn(".claude/settings.json", entry["files_written"])
+
+        # Now remove. The pre-existing file should NOT be deleted.
+        rc = remove_mod.remove(self.target, "claude-code", yes=True, log=lambda _: None)
+        self.assertEqual(rc, 0)
+        self.assertTrue(
+            custom_settings.exists(),
+            "remove deleted .claude/settings.json which pre-existed install — "
+            "this destroys user data",
+        )
+
+    def test_merge_alert_recorded_in_install_json(self):
+        """Codex P1: merge-alerted adapters must record they need manual merge."""
+        # Plant a pre-existing AGENTS.md without .agent/ reference (e.g. user's
+        # own Aider AGENTS.md). Install openclaw — its AGENTS.md uses
+        # merge_or_alert, so it leaves the existing alone but records the alert.
+        existing_agents = self.target / "AGENTS.md"
+        existing_agents.write_text(
+            "# my own AGENTS.md\nSome unrelated rules.\n", encoding="utf-8"
+        )
+        self._install("openclaw")
+        doc = state_mod.load(self.target)
+        entry = doc["adapters"]["openclaw"]
+        # The user's AGENTS.md was preserved, AND we recorded the alert.
+        self.assertIn("AGENTS.md", entry["files_alerted"])
+        self.assertNotIn("AGENTS.md", entry["files_written"])
+
+    def test_doctor_yellow_when_merge_alert_unresolved(self):
+        """Codex P1: doctor must flag yellow if merge_alert hasn't been resolved."""
+        existing_agents = self.target / "AGENTS.md"
+        existing_agents.write_text(
+            "# my own AGENTS.md\nNo .agent reference here.\n", encoding="utf-8"
+        )
+        self._install("openclaw")
+        # Doctor should return 0 (yellow is not red), but the audit text
+        # should mention the unresolved merge.
+        log_lines = []
+        rc = doctor_mod.audit(self.target, log=log_lines.append)
+        self.assertEqual(rc, 0)  # yellow ≠ red
+        all_text = "\n".join(log_lines)
+        self.assertIn("merge required", all_text)
+        self.assertIn("AGENTS.md", all_text)
+
+    def test_doctor_green_when_merge_alert_resolved(self):
+        """Once user merges the snippet (file references .agent/), doctor goes green."""
+        existing_agents = self.target / "AGENTS.md"
+        existing_agents.write_text(
+            "# my own AGENTS.md\nNo reference yet.\n", encoding="utf-8"
+        )
+        self._install("openclaw")
+        # User merges the snippet — append a .agent/ reference.
+        existing_agents.write_text(
+            existing_agents.read_text() + "\nSee .agent/AGENTS.md for the brain.\n",
+            encoding="utf-8",
+        )
+        log_lines = []
+        rc = doctor_mod.audit(self.target, log=log_lines.append)
+        self.assertEqual(rc, 0)
+        all_text = "\n".join(log_lines)
+        self.assertNotIn("merge required", all_text)
+
+    def test_openclaw_agent_name_matches_legacy_cksum(self):
+        """Codex P1: openclaw agent name must match the bash cksum algorithm.
+
+        Pre-v0.9.0 install.sh derived the suffix as:
+          printf '%s' "$ABS" | cksum | awk '{print $1}'  → suffix = N % 1000000
+        v0.9.0 must produce the SAME name for the SAME path, otherwise upgrade
+        installs create duplicate openclaw agents.
+        """
+        from harness_manager.post_install import _openclaw_agent_name, _posix_cksum
+        # Spot check: an absolute path, what the bash would have produced.
+        # Hand-verify against `printf '%s' '/Users/foo/myproject' | cksum | awk '{print $1}'`
+        # → 4089408017, mod 1_000_000 → 408017, padded → "408017"
+        # Basename "myproject" lowercased → "myproject"
+        # Final agent name → "myproject-408017"
+        self.assertEqual(
+            _openclaw_agent_name("/Users/foo/myproject"),
+            "myproject-408017",
+            "openclaw agent name diverged from legacy cksum-based formula",
+        )
+        # Also verify the cksum primitive itself matches POSIX cksum(1).
+        self.assertEqual(_posix_cksum(b"/Users/foo/myproject"), 4089408017)
+
+    def test_state_lock_prevents_lost_update(self):
+        """Codex P2: concurrent upsert_adapter must not lose entries.
+
+        Spawn N processes that each upsert a distinct adapter. With the lock
+        held around the read-modify-write, all N entries land in install.json.
+        Without the lock (the bug codex caught), some are lost.
+        """
+        import multiprocessing as mp
+
+        # Need an installed brain for state.upsert_adapter to write under.
+        self._install("cursor")
+        # Pre-clean: collapse to a known starting state.
+        doc = state_mod.load(self.target)
+        doc["adapters"] = {}
+        state_mod.save(self.target, doc)
+
+        n = 20
+        with mp.Pool(n) as pool:
+            pool.map(_concurrent_upsert_worker, [(str(self.target), i) for i in range(n)])
+
+        doc = state_mod.load(self.target)
+        names = sorted(doc["adapters"].keys())
+        self.assertEqual(
+            len(names),
+            n,
+            f"lost-update under concurrency: expected {n} adapters, got {len(names)}: {names}",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_install_e2e.py
+++ b/tests/test_install_e2e.py
@@ -372,6 +372,84 @@ class TestEndToEndInstallFlow(unittest.TestCase):
             f"skipped at install time. log:\n{all_text}",
         )
 
+    def test_reinstall_preserves_installer_ownership(self):
+        """Codex P1: re-installing an adapter must NOT reclassify our own files
+        as user-owned, otherwise remove leaves them behind on upgrade.
+        """
+        # First install: we create CLAUDE.md fresh.
+        self._install("claude-code")
+        doc1 = state_mod.load(self.target)
+        self.assertIn("CLAUDE.md", doc1["adapters"]["claude-code"]["files_written"])
+
+        # Second install: CLAUDE.md exists (we wrote it), but we still own it.
+        # The re-install should NOT move it to files_overwritten.
+        self._install("claude-code")
+        doc2 = state_mod.load(self.target)
+        entry = doc2["adapters"]["claude-code"]
+        self.assertIn(
+            "CLAUDE.md",
+            entry["files_written"],
+            "reinstall reclassified installer-owned CLAUDE.md as user-owned; "
+            "remove will now leave it behind",
+        )
+        self.assertNotIn("CLAUDE.md", entry["files_overwritten"])
+
+        # Sanity: remove on the re-installed adapter still cleans up our files.
+        rc = remove_mod.remove(self.target, "claude-code", yes=True, log=lambda _: None)
+        self.assertEqual(rc, 0)
+        self.assertFalse((self.target / "CLAUDE.md").exists())
+
+    def test_remove_does_not_reverse_skipped_post_install(self):
+        """Codex P2: remove must NOT reverse post_install actions that never
+        succeeded at install time. Reversing a never-completed openclaw
+        registration could delete a manually-created agent.
+        """
+        # Construct an install.json directly with a synthetic post_install
+        # result that recorded binary_missing. Then run remove with --yes
+        # and verify the reverse list is empty (no openclaw subprocess call).
+        from harness_manager import post_install as pi_mod
+
+        # Plant a fake adapter entry where openclaw_register_workspace was
+        # recorded as binary_missing.
+        state_mod.upsert_adapter(
+            self.target,
+            "openclaw",
+            {
+                "installed_at": "x",
+                "files_written": [],
+                "files_overwritten": [],
+                "files_alerted": [],
+                "file_results": [],
+                "post_install_results": [
+                    {
+                        "action": "openclaw_register_workspace",
+                        "status": "binary_missing",
+                        "agent_name": "would-be-agent-name",
+                    }
+                ],
+            },
+            "0.9.0",
+        )
+
+        # Spy on pi_mod.reverse to ensure it is NOT called for the
+        # binary_missing entry.
+        original_reverse = pi_mod.reverse
+        called_with = []
+        def _spy(action, target_root, **kwargs):
+            called_with.append(action)
+            return original_reverse(action, target_root, **kwargs)
+        pi_mod.reverse = _spy
+        try:
+            rc = remove_mod.remove(self.target, "openclaw", yes=True, log=lambda _: None)
+            self.assertEqual(rc, 0)
+            self.assertEqual(
+                called_with, [],
+                f"remove called reverse() for an unsuccessful post_install: {called_with}. "
+                f"This could delete a manually-created openclaw agent."
+            )
+        finally:
+            pi_mod.reverse = original_reverse
+
     def test_state_lock_prevents_lost_update(self):
         """Codex P2: concurrent upsert_adapter must not lose entries.
 

--- a/tests/test_install_e2e.py
+++ b/tests/test_install_e2e.py
@@ -562,11 +562,18 @@ class TestEndToEndInstallFlow(unittest.TestCase):
           - subsequent add reclassifies our own files as user-owned
         """
         # Simulate a pre-v0.9 install: drop the files the old install.sh
-        # would have written, but no install.json.
+        # would have written, but no install.json. Brain triple
+        # (memory/skills/protocols) is required so state.brain_present
+        # returns True — doctor's synthesis gates on that to avoid
+        # writing bogus install.json in random repos that happen to
+        # contain a common filename.
         (self.target / ".cursor" / "rules").mkdir(parents=True)
         (self.target / ".cursor" / "rules" / "agentic-stack.mdc").write_text("rules", encoding="utf-8")
         (self.target / ".agent").mkdir()
         (self.target / ".agent" / "AGENTS.md").write_text("brain", encoding="utf-8")
+        (self.target / ".agent" / "memory").mkdir()
+        (self.target / ".agent" / "skills").mkdir()
+        (self.target / ".agent" / "protocols").mkdir()
 
         self.assertIsNone(state_mod.load(self.target), "no install.json yet")
 
@@ -613,6 +620,9 @@ class TestEndToEndInstallFlow(unittest.TestCase):
         (self.target / ".agents" / "skills").mkdir(parents=True)
         (self.target / ".agent").mkdir(exist_ok=True)
         (self.target / ".agent" / "AGENTS.md").write_text("brain", encoding="utf-8")
+        (self.target / ".agent" / "memory").mkdir()
+        (self.target / ".agent" / "skills").mkdir()
+        (self.target / ".agent" / "protocols").mkdir()
 
         import builtins
         from unittest.mock import patch

--- a/tests/test_install_e2e.py
+++ b/tests/test_install_e2e.py
@@ -589,11 +589,14 @@ class TestEndToEndInstallFlow(unittest.TestCase):
         self.assertIsNotNone(doc, "doctor failed to synthesize install.json")
         self.assertIn("cursor", doc["adapters"])
         cursor_entry = doc["adapters"]["cursor"]
+        # Conservative migration: detected file goes to files_overwritten
+        # (we don't know whether it pre-existed user content). User can
+        # re-install for strict ownership tracking.
         self.assertIn(
             ".cursor/rules/agentic-stack.mdc",
-            cursor_entry["files_written"],
-            "synthesis must populate files_written so remove can clean up "
-            "pre-v0.9 install artifacts",
+            cursor_entry["files_overwritten"],
+            "synthesis must populate files_overwritten conservatively so "
+            "remove never destroys content we can't prove we created",
         )
         self.assertTrue(cursor_entry.get("_synthesized"))
 
@@ -661,6 +664,35 @@ class TestEndToEndInstallFlow(unittest.TestCase):
             )
             # Hand-verified pre-v0.9 install.sh value
             self.assertEqual(name, "myproject-408017")
+
+    def test_remove_preserves_shared_agents_md(self):
+        """Codex P1: a multi-adapter repo where another adapter still
+        depends on AGENTS.md must NOT see it deleted by remove.
+        """
+        # Install codex first — writes AGENTS.md (merge_or_alert; we create
+        # it because target is fresh).
+        self._install("codex")
+        doc = state_mod.load(self.target)
+        codex_entry = doc["adapters"]["codex"]
+        self.assertIn("AGENTS.md", codex_entry["files_written"])
+
+        # Add hermes — its AGENTS.md merge_policy is merge_or_alert; existing
+        # AGENTS.md already references .agent/ (codex's content) → left_alone.
+        self._install("hermes")
+        doc = state_mod.load(self.target)
+        hermes_entry = doc["adapters"]["hermes"]
+        # hermes recorded AGENTS.md in file_results as left_alone, NOT in files_written.
+        hermes_results = {r["dst"]: r["result"] for r in hermes_entry["file_results"]}
+        self.assertEqual(hermes_results.get("AGENTS.md"), "left_alone")
+
+        # Now remove codex. AGENTS.md is in codex's files_written, but hermes
+        # depends on it. The shared check must preserve it.
+        rc = remove_mod.remove(self.target, "codex", yes=True, log=lambda _: None)
+        self.assertEqual(rc, 0)
+        self.assertTrue(
+            (self.target / "AGENTS.md").exists(),
+            "remove deleted AGENTS.md while another adapter (hermes) still depends on it",
+        )
 
     def test_state_lock_prevents_lost_update(self):
         """Codex P2: concurrent upsert_adapter must not lose entries.


### PR DESCRIPTION
## Summary

- New manifest-driven adapter backend (`harness_manager/`): `adapter.json` per harness declares files, merge policies, and post-install actions; Python dispatcher replaces inline bash logic in `install.sh` / `install.ps1`.
- Verb subcommands: `add`, `remove`, `doctor`, `status`, `manage` (interactive TUI). Bare `./install.sh` opens the onboarding wizard with multi-select adapter picking and auto-detect of installed harnesses.
- Closes #18 by introducing `brain_root_primitive` substitution: `claude-code/settings.json` hook commands now use `$CLAUDE_PROJECT_DIR` (Claude Code's canonical primitive for project root) instead of cwd-relative paths.

## What's in the box

- 10 adapters with manifests (claude-code, cursor, windsurf, opencode, openclaw, hermes, pi, codex, antigravity, standalone-python).
- Pre-v0.9 migration path via `./install.sh doctor` — synthesizes `install.json` from on-disk signals so legacy installs become first-class tracked entries.
- Cross-platform: same Python backend serves install.sh (POSIX) and install.ps1 (Windows). `state.py` locking via fcntl on POSIX, msvcrt on Windows.
- POSIX cksum + SHA1 dual-hash for openclaw agent name stability across platforms (matches legacy bash and PowerShell installers exactly).
- 40 e2e tests covering install / reinstall / remove / doctor / synthesis / shared-files.

## Codex review

9 rounds of `codex review --base master` against this branch. Each round's findings landed as a separate fix commit. Final round green except for openclaw lifecycle correctness items (P2s) that were addressed in the last commit. Latest commit message has the full list.

## Test plan

- [ ] `./install.sh` in a fresh dir → multi-select wizard appears, auto-detects nothing, lets you pick harnesses
- [ ] `./install.sh claude-code /tmp/x` → installs, runs onboard, offers manage TUI at end
- [ ] `./install.sh manage` in a project with installed adapters → header shows green/yellow/red status, menu lets you add/remove/audit
- [ ] `./install.sh doctor` on a pre-v0.9 project (brain present + adapter signals) → prompts to synthesize
- [ ] `./install.sh doctor` in a random repo with `.agent/` for unrelated reasons → exits cleanly without offering synthesis (round 7 fix)
- [ ] `./install.sh remove claude-code` → confirms file list, skips shared files, only reverses post_install actions we performed (round 9 fix)
- [ ] Verify CLAUDE.md hook from a subdirectory → no "no such file or directory" (closes #18)

Closes #18.