### PR TITLE
fix(memory): recover short CJK search matches

### DIFF
--- a/.agent/memory/memory_search.py
+++ b/.agent/memory/memory_search.py
@@ -21,6 +21,7 @@ The index is stored at .agent/memory/.index/memory.db and auto-rebuilds
 when any memory file changes, is renamed, or is deleted.
 """
 import json
+import re
 import shutil
 import sys
 import sqlite3
@@ -34,6 +35,7 @@ FEATURES_PATH = MEMORY_DIR / ".features.json"
 
 # Files we consider "memory documents" for both indexing and search.
 MEMORY_SUFFIXES = (".md", ".jsonl")
+CJK_RE = re.compile(r"[\u3400-\u9fff]")
 
 
 def feature_enabled() -> bool:
@@ -170,6 +172,15 @@ def search_fts5(query: str):
         ).fetchall()
     except sqlite3.OperationalError:
         # Query syntax error — fall back to LIKE
+        rows = conn.execute(
+            "SELECT filename, substr(content, 1, 300) FROM memories WHERE content LIKE ?",
+            (f"%{query}%",),
+        ).fetchall()
+
+    # SQLite's unicode61 tokenizer is good for mixed Latin/CJK text, but it
+    # does not segment every short CJK substring the way users expect. Keep the
+    # fast FTS path first, then recover exact CJK substring matches.
+    if not rows and CJK_RE.search(query):
         rows = conn.execute(
             "SELECT filename, substr(content, 1, 300) FROM memories WHERE content LIKE ?",
             (f"%{query}%",),

--- a/test_memory_search.py
+++ b/test_memory_search.py
@@ -1,0 +1,81 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+MEMORY_SEARCH = ROOT / ".agent" / "memory" / "memory_search.py"
+
+
+def load_memory_search():
+    spec = importlib.util.spec_from_file_location("memory_search", MEMORY_SEARCH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class MemorySearchTest(unittest.TestCase):
+    def with_memory_root(self):
+        tmp = tempfile.TemporaryDirectory()
+        root = Path(tmp.name) / ".agent" / "memory"
+        (root / "semantic").mkdir(parents=True)
+        (root / "episodic").mkdir()
+        (root / ".features.json").write_text(
+            json.dumps({"memory_search_fts": {"enabled": True}}),
+            encoding="utf-8",
+        )
+
+        module = load_memory_search()
+        module.MEMORY_DIR = root
+        module.INDEX_DIR = root / ".index"
+        module.INDEX_PATH = module.INDEX_DIR / "memory.db"
+        module.FEATURES_PATH = root / ".features.json"
+        return tmp, root, module
+
+    def test_short_cjk_query_matches_inside_longer_phrase(self):
+        tmp, root, memory_search = self.with_memory_root()
+        self.addCleanup(tmp.cleanup)
+
+        (root / "semantic" / "LESSONS.md").write_text(
+            "- 中文优先 when the user writes in Chinese.\n",
+            encoding="utf-8",
+        )
+
+        rows = memory_search.search_fts5("中文")
+
+        self.assertEqual(rows[0][0], "semantic/LESSONS.md")
+        self.assertIn("中文优先", rows[0][1])
+
+    def test_mixed_english_cjk_query_uses_fts5(self):
+        tmp, root, memory_search = self.with_memory_root()
+        self.addCleanup(tmp.cleanup)
+
+        (root / "semantic" / "LESSONS.md").write_text(
+            "- OpenClaw 飞书 document retrieval needs tab-aware recovery.\n",
+            encoding="utf-8",
+        )
+
+        rows = memory_search.search_fts5("OpenClaw 飞书")
+
+        self.assertEqual(rows[0][0], "semantic/LESSONS.md")
+        self.assertIn("OpenClaw", rows[0][1])
+        self.assertIn("飞书", rows[0][1])
+
+    def test_deleted_memory_file_is_removed_on_rebuild(self):
+        tmp, root, memory_search = self.with_memory_root()
+        self.addCleanup(tmp.cleanup)
+
+        note = root / "semantic" / "LESSONS.md"
+        note.write_text("- Keep stale anchors out of search results.\n", encoding="utf-8")
+        self.assertTrue(memory_search.search_fts5("stale anchors"))
+
+        note.unlink()
+        rows = memory_search.search_fts5("stale anchors")
+
+        self.assertEqual(rows, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- make memory search recover short CJK substring matches when FTS5 returns nothing
- add regression tests for short CJK, mixed English/CJK, and deleted-file rebuilds

## Why

The FTS5 `unicode61` tokenizer handles mixed English/CJK queries pretty well, but it can miss short substring searches inside longer CJK phrases. For example, `中文` did not match a memory line containing `中文优先`.

That is a small miss, but it matters here: agentic-stack uses memory as the portable layer across harnesses, so language preferences and bilingual project notes should stay findable.

## Validation

- `python3 -m unittest test_memory_search.py`
- `python3 -m unittest test_memory_search.py test_claude_code_hook.py test_data_layer_export.py test_data_flywheel_export.py`
- `python3 -m py_compile .agent/memory/memory_search.py test_memory_search.py`
- `git diff --check`
- `python3 verify_codex_fixes.py`

I also ran hermescheck before/after locally; its multilingual memory retrieval test gap no longer appears after this patch.
