### PR TITLE
feat: add gemini-cli adapter as fork-specific feature

### DIFF
--- a/ADAPTERS.md
+++ b/ADAPTERS.md
@@ -1,0 +1,55 @@
+# Available Adapters
+
+## Core adapters (master branch — synced with upstream)
+
+These adapters are available in the `master` branch, which tracks upstream
+`codejunkie99/agentic-stack` cleanly.
+
+- `claude-code`
+- `cursor`
+- `windsurf`
+- `opencode`
+- `openclaw`
+- `hermes`
+- `pi`
+- `codex`
+- `standalone-python`
+- `antigravity`
+
+Install from master:
+```bash
+./install.sh <adapter-name>
+```
+
+## Fork-specific adapters (feature branches)
+
+These adapters are maintained in dedicated feature branches and are NOT
+merged into master. This keeps master clean for upstream sync.
+
+### `gemini-cli` (branch: `feat/gemini-cli`)
+
+Google Gemini CLI adapter. Adds `GEMINI.md` project context and an MCP server
+bridge exposing `recall`, `memory_reflect`, `learn`, and `agentic_status` as
+tools. Custom slash commands in `.gemini/commands/agentic/`.
+
+Install from the feature branch:
+```bash
+git checkout feat/gemini-cli
+./install.sh gemini-cli
+```
+
+See `docs/per-harness/gemini-cli.md` for MCP server registration instructions.
+
+## Adding new fork-specific adapters
+
+1. Create a feature branch from master:
+   ```bash
+   git checkout master
+   git checkout -b feat/<adapter-name>
+   ```
+2. Add adapter files under `adapters/<adapter-name>/`
+3. Add per-harness docs under `docs/per-harness/<adapter-name>.md`
+4. Update this file (`ADAPTERS.md`) with the new adapter
+5. Update `install.sh` / `install.ps1` comments to list the fork adapter
+6. Push: `git push fork feat/<adapter-name>`
+7. **Never merge the feature branch into master**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to this project.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [fork/gemini-cli] — 2026-05-05 (branch: feat/gemini-cli)
+
+Fork-specific feature. Adds a `gemini-cli` adapter so the portable brain
+works with Google's Gemini CLI via its native MCP server extension mechanism.
+
+### Added
+- **`gemini-cli` adapter.** Adds `adapters/gemini-cli/` with an
+`adapter.json` manifest, `GEMINI.md` project context, an MCP server
+bridge (`mcp-server.js` + `mcp-package.json`) that exposes `recall`,
+`memory_reflect`, `learn`, and `agentic_status` as MCP tools, and four
+custom TOML slash commands (`/agentic:recall`, `/agentic:learn`,
+`/agentic:status`, `/agentic:reflect`).
+- **Per-harness docs.** Adds `docs/per-harness/gemini-cli.md` covering
+install, MCP server registration, tool reference, slash commands, and
+troubleshooting.
+- **Validation suite.** Adds `test_gemini_mcp.py` with 15 checks: manifest
+validation, GEMINI.md wiring, MCP server syntax/imports/tool
+registration, package.json deps/engines, TOML command fields, docs, and
+install/remove cycle.
+
+### Changed
+- Supported harness count is now eleven: Claude Code, Cursor, Windsurf,
+OpenCode, OpenClaw, Hermes, Pi, Codex, Standalone Python, Antigravity,
+and Gemini CLI.
+- The adapter installs MCP server files into
+`<project>/.gemini/agentic-stack-mcp/` and custom commands into
+`<project>/.gemini/commands/agentic/`. Users must register the MCP
+server in `.gemini/settings.json` manually (documented in the per-harness
+guide and adapter README).
+- Fixed `opencode.json` permission key: renamed `"permissions"` to
+`"permission"` to match the opencode config schema.
+
+### Fixed
+- n/a
+
+### Migration
+No migration required. Existing installs are unaffected. The gemini-cli
+adapter is purely additive. Install with `./install.sh gemini-cli`.
+
 ## [0.13.0] — 2026-05-02
 
 Minor release. Adds an onboarding-style transfer wizard for moving a portable
@@ -13,33 +52,33 @@ generated curl/PowerShell import command.
 
 ### Added
 - **`agentic-stack transfer` wizard.** Adds an onboarding-style TUI that parses
-  natural-language requests such as `move my memory into Codex`, previews the
-  target adapter files, asks for confirmation, and either generates an import
-  command, applies locally, or both.
+natural-language requests such as `move my memory into Codex`, previews the
+target adapter files, asks for confirmation, and either generates an import
+command, applies locally, or both.
 - **Portable transfer bundles.** Adds canonical JSON + gzip + base64url
-  bundles with SHA-256 verification. The importer merges preferences and
-  accepted lessons idempotently, restores selected memory files, copies skills,
-  records import metadata, and installs selected adapters through the existing
-  harness manager.
+bundles with SHA-256 verification. The importer merges preferences and
+accepted lessons idempotently, restores selected memory files, copies skills,
+records import metadata, and installs selected adapters through the existing
+harness manager.
 - **Full memory intent.** `move my memory` now means preferences, accepted
-  lessons, skills, working memory, episodic/history logs, and candidate
-  lessons. Data-layer exports, flywheel traces, runtime indexes, and caches
-  stay out unless future scopes explicitly add them.
+lessons, skills, working memory, episodic/history logs, and candidate
+lessons. Data-layer exports, flywheel traces, runtime indexes, and caches
+stay out unless future scopes explicitly add them.
 - **Curl and PowerShell bootstraps.** Adds `scripts/import-transfer.sh` and
-  `scripts/import-transfer.ps1` so another terminal can import a transfer
-  bundle without manually cloning the repo first.
+`scripts/import-transfer.ps1` so another terminal can import a transfer
+bundle without manually cloning the repo first.
 
 ### Changed
 - Windsurf installs a modern `.windsurf/rules/agentic-stack.md` workspace rule
-  and still writes legacy `.windsurfrules` for older Windsurf builds.
+and still writes legacy `.windsurfrules` for older Windsurf builds.
 - `agentic-stack transfer export` and `agentic-stack transfer import` provide
-  non-interactive surfaces for scripts and CI-style handoff flows.
+non-interactive surfaces for scripts and CI-style handoff flows.
 
 ### Fixed
 - Transfer export blocks secret-like content, including private keys and common
-  API token patterns, before payload generation.
+API token patterns, before payload generation.
 - Fresh Codex imports now copy the full `.agent` brain before installing the
-  Codex `AGENTS.md` and `.agents/skills` adapter wiring.
+Codex `AGENTS.md` and `.agents/skills` adapter wiring.
 
 ### Migration
 No migration required. Existing installs keep working. Run
@@ -50,9 +89,9 @@ import a transfer bundle.
 - Tag `v0.13.0` cut from master.
 - GitHub release: <https://github.com/codejunkie99/agentic-stack/releases/tag/v0.13.0>
 - `Formula/agentic-stack.rb` bumped to v0.13.0 in a follow-up commit after
-  the tag tarball existed and its sha256 could be computed.
+the tag tarball existed and its sha256 could be computed.
 - Tarball sha256:
-  `83f71bab05bd607f3590571b5422a0cc74650d69ff5d818b6682d0f877e16514`.
+`83f71bab05bd607f3590571b5422a0cc74650d69ff5d818b6682d0f877e16514`.
 
 ## [0.12.0] — 2026-04-27
 

--- a/FORK_SYNC.md
+++ b/FORK_SYNC.md
@@ -1,0 +1,112 @@
+# Fork Synchronization Guide
+
+This document explains how to keep this fork (`conrackx/agentic-stack-plus`)
+in sync with the upstream repo (`codejunkie99/agentic-stack`) while
+maintaining fork-specific features in dedicated branches.
+
+## Remotes
+
+```
+origin  https://github.com/codejunkie99/agentic-stack.git  (upstream)
+fork    git@github.com:conrackx/agentic-stack-plus.git     (fork)
+```
+
+## Branch Strategy
+
+```
+master                — CLEAN mirror of upstream. Never modified by fork.
+feat/gemini-cli       — Gemini CLI adapter (fork-specific)
+feat/<adapter-name>   — Future fork-specific adapters
+```
+
+**master is NEVER modified by the fork.** It only receives fast-forward
+merges from upstream. All fork-specific work lives in feature branches.
+
+## Sync Procedure (run regularly)
+
+```bash
+# 1. Fetch latest upstream changes
+git fetch origin
+
+# 2. Update master (clean fast-forward only)
+git checkout master
+git merge origin/master --ff-only
+git push fork master
+
+# 3. Rebase each feature branch onto updated master
+git checkout feat/gemini-cli
+git rebase master
+git push fork feat/gemini-cli --force-with-lease
+```
+
+## NEVER do these on master
+
+- Add fork-specific adapters or files
+- Modify CHANGELOG.md with fork-only entries
+- Bump version differently from upstream
+- Merge from feature branches
+- Commit any fork-specific changes
+
+## ALWAYS do these on feature branches
+
+- Develop fork-specific adapters
+- Add fork-specific CHANGELOG entries (under a `[fork/<name>]` section)
+- Update install.sh / install.ps1 comments to list fork adapters
+- Update README.md to document fork features
+- Update ADAPTERS.md with new fork adapters
+
+## Resolving Rebase Conflicts
+
+When rebasing a feature branch onto updated master, common conflicts:
+
+### CHANGELOG.md
+- Upstream added a new release section at the top
+- Your feature branch also added a section at the top
+- **Resolution:** Keep both sections. Fork entries use `[fork/<name>]`
+  format (not a semver version) so they never collide with upstream versions.
+
+### README.md
+- Upstream updated the "New in vX.Y.Z" section
+- Your feature branch added a fork feature section
+- **Resolution:** Keep upstream's "New in" section. Your fork section
+  goes below it with a clear "Fork feature:" prefix.
+
+### install.sh / install.ps1
+- Upstream may have reformatted comments
+- **Resolution:** Keep upstream's core adapter list. Add fork adapter
+  on a separate comment line: `# Fork adapters (branch: feat/X): X`
+
+## Fork-specific files to preserve during rebase
+
+These files exist only in feature branches and must be preserved:
+
+### feat/gemini-cli branch:
+- `adapters/gemini-cli/` (10 files)
+- `docs/per-harness/gemini-cli.md`
+- `test_gemini_mcp.py`
+- `adapters/opencode/opencode.json` (fixed `permission` key)
+- `ADAPTERS.md`
+- `FORK_SYNC.md`
+
+## Version Collision Prevention
+
+The v0.13.0 collision taught us:
+
+1. **Check upstream before any version work:** `git fetch origin && git log origin/master --oneline -5`
+2. **Never bump version on a feature branch** using a semver number that
+   upstream might use. Use `[fork/<feature-name>]` format instead.
+3. **Sync master before starting new work:** Always `git merge origin/master --ff-only` on master, then rebase your feature branch.
+4. **Keep CHANGELOG entries separate:** Fork entries use `[fork/<name>]`
+   format so they never collide with upstream `[X.Y.Z]` entries.
+
+## Agent instructions for future syncs
+
+1. Read this file (`FORK_SYNC.md`) first.
+2. Read `ADAPTERS.md` to understand which adapters live where.
+3. **On master:** Only `git merge origin/master --ff-only && git push fork master`.
+4. **On feature branches:** Rebase onto master, resolve conflicts per rules above.
+5. Never merge feature branches into master.
+6. Never delete fork-specific files during rebase.
+7. After resolving conflicts, run `python3 test_gemini_mcp.py` on the
+   feat/gemini-cli branch to verify adapter integrity.
+8. Push to fork remote (`fork`, not `origin`).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Keep one portable memory-and-skills layer across coding-agent harnesses, so switching tools doesn't reset how your agent works.**
 
-A portable `.agent/` folder (memory + skills + protocols) that plugs into Claude Code, Cursor, Windsurf, OpenCode, OpenClaw, Hermes, Pi Coding Agent, Codex, Antigravity, or a DIY Python loop — and keeps its knowledge when you switch.
+A portable `.agent/` folder (memory + skills + protocols) that plugs into Claude Code, Cursor, Windsurf, OpenCode, OpenClaw, Hermes, Pi Coding Agent, Codex, Gemini CLI, Antigravity, or a DIY Python loop — and keeps its knowledge when you switch.
 
 It also includes a local data layer so you can monitor the whole suite of
 agents from one place: harness activity, cron runs, active agents, token/cost
@@ -43,6 +43,18 @@ moving a project brain into Codex, Cursor, Windsurf, or a terminal-only
   while keeping legacy `.windsurfrules` compatibility.
 
 See [CHANGELOG.md](CHANGELOG.md) for the full list.
+
+### Fork feature: gemini-cli adapter (branch: feat/gemini-cli)
+
+This fork adds a `gemini-cli` adapter so the portable brain works with Google's
+Gemini CLI via its native MCP server extension mechanism.
+
+- **MCP server bridge.** Exposes `recall`, `memory_reflect`, `learn`, and
+`agentic_status` as MCP tools Gemini CLI can invoke directly.
+- **Custom slash commands.** `/agentic:recall`, `/agentic:learn`,
+`/agentic:status`, `/agentic:reflect`.
+- **Per-harness docs.** See `docs/per-harness/gemini-cli.md` for setup
+instructions including MCP server registration.
 
 ### v0.12.0 — tldraw visual canvas
 
@@ -114,7 +126,7 @@ brew install agentic-stack
 # drop the brain into any project — the onboarding wizard runs automatically
 cd your-project
 agentic-stack claude-code
-# or: cursor | windsurf | opencode | openclaw | hermes | pi | codex | standalone-python | antigravity
+# or: cursor | windsurf | opencode | openclaw | hermes | pi | codex | standalone-python | antigravity | gemini-cli
 ```
 
 ### Windows (PowerShell)
@@ -138,7 +150,7 @@ brew update && brew upgrade agentic-stack
 git clone https://github.com/codejunkie99/agentic-stack.git
 cd agentic-stack && ./install.sh claude-code         # mac / linux / git-bash
 # or on Windows PowerShell: .\install.ps1 claude-code
-# adapters: claude-code | cursor | windsurf | opencode | openclaw | hermes | pi | codex | standalone-python | antigravity
+# adapters: claude-code | cursor | windsurf | opencode | openclaw | hermes | pi | codex | standalone-python | antigravity | gemini-cli
 ```
 
 ### Once installed: manage what's wired
@@ -356,7 +368,8 @@ adapters/                       # one small shim per harness, each with adapter.
 ├── pi/            (AGENTS.md + .pi/skills symlink)
 ├── codex/         (AGENTS.md + .agents/skills symlink)
 ├── standalone-python/  (DIY conductor entrypoint)
-└── antigravity/   (ANTIGRAVITY.md)
+└── antigravity/ (ANTIGRAVITY.md)
+└── gemini-cli/ (GEMINI.md + MCP server bridge + custom commands)
 
 harness_manager/                # v0.9.0 manifest-driven Python backend
 ├── schema.py                   # adapter.json validator (path-safe on POSIX + Windows)
@@ -404,6 +417,7 @@ verify_codex_fixes.py           # v0.8.0 regression checks (33 checks)
 | **Codex** | `AGENTS.md` + `.agents/skills/` | no (manual reflect calls) |
 | **Standalone Python** | `run.py` (any LLM) | yes (full control) |
 | **Antigravity** | `ANTIGRAVITY.md` | yes (system context) |
+| **Gemini CLI** | `GEMINI.md` + `.gemini/settings.json` (MCP) | partial (MCP tools, custom commands) |
 
 ## Seed skills
 

--- a/adapters/gemini-cli/GEMINI.md
+++ b/adapters/gemini-cli/GEMINI.md
@@ -1,0 +1,77 @@
+# Project Instructions (Gemini CLI)
+
+This project uses the **agentic-stack** portable brain. All memory, skills,
+and protocols live in `.agent/`.
+
+## Before doing anything
+
+1. Read `.agent/AGENTS.md` — it's the map.
+2. Read `.agent/memory/personal/PREFERENCES.md` — how the user works.
+3. Read `.agent/memory/semantic/LESSONS.md` — what we've learned.
+4. Read `.agent/protocols/permissions.md` — what you can and cannot do.
+
+## Before every non-trivial task — recall first
+
+For any task involving **deploy**, **ship**, **release**, **migration**,
+**schema change**, **timestamp** / **timezone** / **date**, **failing test**,
+**debug**, **investigate**, or **refactor**, run recall FIRST and present
+the surfaced lessons to yourself before acting:
+
+```bash
+python3 .agent/tools/recall.py "<one-line description of what you're about to do>"
+```
+
+If the output contains a "Consulted lessons for intent:" block with one or
+more results, show them in a `Consulted lessons before acting:` block and
+adjust your plan to respect them. If a surfaced lesson would be violated by
+your intended action, stop and explain.
+
+This is how graduated lessons actually change behavior across harnesses.
+Skip it and the system is just files on disk.
+
+## MCP tools
+
+The agentic-stack MCP server is pre-configured in `.gemini/settings.json`.
+It exposes these tools:
+
+| Tool | What it does |
+|---|---|
+| `recall` | Surface graduated lessons relevant to an intent |
+| `memory_reflect` | Log a significant event to episodic memory |
+| `learn` | Teach the agent a new rule in one shot |
+| `agentic_status` | Show brain-state dashboard (episodes, candidates, lessons) |
+
+Use the tools directly when the model decides to; you can also invoke them
+via slash commands:
+
+- `/agentic:recall <intent>` — query memory before a task
+- `/agentic:learn <rule>` — store a new lesson
+- `/agentic:status` — quick brain-state check
+- `/agentic:reflect <skill> <action> <outcome>` — log a significant event
+
+## While working
+
+- Consult `.agent/skills/_index.md` and load the full `SKILL.md` for any
+  skill whose triggers match the task.
+- Update `.agent/memory/working/WORKSPACE.md` as the task evolves.
+- Log significant actions to `.agent/memory/episodic/AGENT_LEARNINGS.jsonl`
+  via `.agent/tools/memory_reflect.py` or the `memory_reflect` MCP tool.
+- Quick state check any time: `python3 .agent/tools/show.py`.
+- Teach the agent a new rule in one shot:
+  `python3 .agent/tools/learn.py "<the rule>" --rationale "<why>"`.
+
+## Visual memory (tldraw, opt-in)
+
+If `.agent/memory/.features.json` has `tldraw.enabled: true`, the `tldraw`
+skill is available. It draws on a live canvas at `http://localhost:3030`
+via the tldraw MCP server configured in `.mcp.json`. Worthwhile drawings
+snapshot into the skill's local store and are recalled with
+`python3 .agent/skills/tldraw/store.py list`. Off by default.
+
+## Rules that override defaults
+
+- Never force push to `main`, `production`, or `staging`.
+- Never delete episodic or semantic memory entries — archive them.
+- Never modify `.agent/protocols/permissions.md`.
+- Prefer using the `agentic-stack` tools for all repository-level learning
+  and recall chores.

--- a/adapters/gemini-cli/README.md
+++ b/adapters/gemini-cli/README.md
@@ -1,0 +1,121 @@
+# Gemini CLI adapter
+
+## Install
+
+```bash
+# from the agentic-stack repo root
+./install.sh gemini-cli /path/to/your-project
+```
+
+Or on Windows PowerShell:
+
+```powershell
+.\install.ps1 gemini-cli C:\path\to\your-project
+```
+
+After the adapter installs its files, you need one manual step:
+
+### Register the MCP server
+
+Add the `agentic-stack-connector` entry to your project or global
+`.gemini/settings.json`. The adapter writes the server files to
+`.gemini/agentic-stack-mcp/`, but gemini-cli does not auto-discover
+MCP servers from the filesystem — you must declare them in settings.
+
+**Project-level** (`.gemini/settings.json` in your project root):
+
+```json
+{
+  "mcpServers": {
+    "agentic-stack-connector": {
+      "command": "node",
+      "args": [".gemini/agentic-stack-mcp/server.js"],
+      "env": {
+        "AGENTIC_PROJECT_DIR": "${PWD}"
+      },
+      "timeout": 30000
+    }
+  }
+}
+```
+
+**Global** (`~/.gemini/settings.json`) — use when all your projects use
+agentic-stack:
+
+```json
+{
+  "mcpServers": {
+    "agentic-stack-connector": {
+      "command": "node",
+      "args": [".gemini/agentic-stack-mcp/server.js"],
+      "env": {
+        "AGENTIC_PROJECT_DIR": "${PWD}"
+      },
+      "timeout": 30000
+    }
+  }
+}
+```
+
+Then install the MCP server's Node.js dependencies:
+
+```bash
+cd .gemini/agentic-stack-mcp && npm install --production
+```
+
+## What it wires up
+
+- `GEMINI.md` — Gemini CLI reads this natively as project context; points
+  it at `.agent/` for memory, skills, and protocols.
+- `.gemini/agentic-stack-mcp/server.js` + `package.json` — MCP server
+  bridge exposing `recall`, `memory_reflect`, `learn`, and `agentic_status`
+  as tools Gemini CLI can invoke directly.
+- `.gemini/commands/agentic/*.toml` — Custom slash commands:
+  `/agentic:recall`, `/agentic:learn`, `/agentic:status`, `/agentic:reflect`.
+
+## Verify
+
+1. Start gemini-cli in the project directory:
+
+   ```bash
+   gemini
+   ```
+
+2. Check the MCP server is connected:
+
+   ```
+   /mcp
+   ```
+
+   Expected: `agentic-stack-connector (CONNECTED)` with four tools listed.
+
+3. Test a tool:
+
+   ```
+   What lessons does my brain have about deploying?
+   ```
+
+   The model should call the `recall` MCP tool automatically.
+
+4. Test a custom command:
+
+   ```
+   /agentic:status
+   ```
+
+   Should show the brain-state dashboard.
+
+## Troubleshooting
+
+- **MCP server DISCONNECTED**: Run `npm install` inside
+  `.gemini/agentic-stack-mcp/`. The server needs `@modelcontextprotocol/sdk`
+  and `zod` as runtime dependencies.
+- **"python3 not found"**: The MCP tools shell out to `python3`. On Windows,
+  the Python launcher `py` may work instead — set a shell alias or ensure
+  `python3` is on PATH.
+- **Tools not appearing in `/mcp`**: Verify the `mcpServers` entry in
+  `.gemini/settings.json` points to the correct `server.js` path and that
+  the `AGENTIC_PROJECT_DIR` env var resolves to the project root.
+- **GEMINI.md not loaded**: Gemini CLI loads `GEMINI.md` from the current
+  working directory on startup. Make sure you launch `gemini` from the
+  project root where the adapter installed `GEMINI.md`.

--- a/adapters/gemini-cli/adapter.json
+++ b/adapters/gemini-cli/adapter.json
@@ -1,0 +1,43 @@
+{
+  "name": "gemini-cli",
+  "description": "Google Gemini CLI — GEMINI.md project context + MCP server bridge exposing recall, memory_reflect, learn, and show as tools. Custom commands in .gemini/commands/agentic/.",
+  "files": [
+    {
+      "src": "GEMINI.md",
+      "dst": "GEMINI.md",
+      "merge_policy": "merge_or_alert"
+    },
+    {
+      "src": "mcp-package.json",
+      "dst": ".gemini/agentic-stack-mcp/package.json",
+      "merge_policy": "skip_if_exists",
+      "substitute": true
+    },
+    {
+      "src": "mcp-server.js",
+      "dst": ".gemini/agentic-stack-mcp/server.js",
+      "merge_policy": "skip_if_exists",
+      "substitute": true
+    },
+    {
+      "src": "commands/agentic-recall.toml",
+      "dst": ".gemini/commands/agentic/recall.toml",
+      "merge_policy": "overwrite"
+    },
+    {
+      "src": "commands/agentic-learn.toml",
+      "dst": ".gemini/commands/agentic/learn.toml",
+      "merge_policy": "overwrite"
+    },
+    {
+      "src": "commands/agentic-status.toml",
+      "dst": ".gemini/commands/agentic/status.toml",
+      "merge_policy": "overwrite"
+    },
+    {
+      "src": "commands/agentic-reflect.toml",
+      "dst": ".gemini/commands/agentic/reflect.toml",
+      "merge_policy": "overwrite"
+    }
+  ]
+}

--- a/adapters/gemini-cli/commands/agentic-learn.toml
+++ b/adapters/gemini-cli/commands/agentic-learn.toml
@@ -1,0 +1,10 @@
+description = "Teach the agentic-stack a new rule that should never be violated again"
+prompt = """
+Teach this rule to the agentic-stack portable brain so future sessions remember it.
+
+Rule: {{args}}
+
+Run: !{python3 .agent/tools/learn.py "{{args}}" --rationale "Rule taught from gemini-cli session"}
+
+Confirm the rule was accepted and will be available in future sessions.
+"""

--- a/adapters/gemini-cli/commands/agentic-recall.toml
+++ b/adapters/gemini-cli/commands/agentic-recall.toml
@@ -1,0 +1,10 @@
+description = "Query agentic-stack memory for lessons relevant to a task before starting it"
+prompt = """
+Before starting this task, query the agentic-stack portable brain for relevant lessons.
+
+Run: !{python3 .agent/tools/recall.py "{{args}}"}
+
+If the output contains a "Consulted lessons for intent:" block with results, present them as a "Consulted lessons before acting:" block and adjust your plan to respect them. If a surfaced lesson would be violated by your intended action, stop and explain why.
+
+Then proceed with the task.
+"""

--- a/adapters/gemini-cli/commands/agentic-reflect.toml
+++ b/adapters/gemini-cli/commands/agentic-reflect.toml
@@ -1,0 +1,12 @@
+description = "Log a significant event to the agentic-stack episodic memory (skill, action, outcome)"
+prompt = """
+Log a significant event to the agentic-stack portable brain's episodic memory.
+
+Details: {{args}}
+
+Expected format: skill action outcome [importance]
+
+Run: !{python3 .agent/tools/memory_reflect.py {{args}}}
+
+Confirm the event was logged. If the importance is 7+, mention that the dream cycle will likely promote this into a candidate lesson.
+"""

--- a/adapters/gemini-cli/commands/agentic-status.toml
+++ b/adapters/gemini-cli/commands/agentic-status.toml
@@ -1,0 +1,8 @@
+description = "Show the current state of the agentic-stack portable brain"
+prompt = """
+Show the current brain-state dashboard for the agentic-stack portable memory.
+
+Run: !{python3 .agent/tools/show.py}
+
+Summarize the key numbers: total episodes, pending candidates, graduated lessons, and any failing skills.
+"""

--- a/adapters/gemini-cli/mcp-package.json
+++ b/adapters/gemini-cli/mcp-package.json
@@ -1,0 +1,19 @@
+{
+  "name": "agentic-stack-mcp",
+  "version": "0.1.0",
+  "description": "MCP server bridge that exposes agentic-stack portable brain tools (recall, memory_reflect, learn, show) to Gemini CLI.",
+  "type": "module",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "install-deps": "npm install --production"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "zod": "^3.24.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "license": "Apache-2.0"
+}

--- a/adapters/gemini-cli/mcp-server.js
+++ b/adapters/gemini-cli/mcp-server.js
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+
+/**
+ * agentic-stack MCP server — bridges the portable brain's Python CLI tools
+ * into Gemini CLI's MCP tool registry.
+ *
+ * Transport: stdio (spawned by gemini-cli, communicates over stdin/stdout).
+ * No network; no API keys. All state stays in .agent/ on disk.
+ *
+ * Install: the adapter's install.sh step writes this file and package.json
+ * into <project>/.gemini/agentic-stack-mcp/ and appends an mcpServers entry
+ * to <project>/.gemini/settings.json (or the user's global settings).
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { z } from "zod";
+
+const execFileAsync = promisify(execFile);
+
+const PROJECT_ROOT = process.env.AGENTIC_PROJECT_DIR || process.cwd();
+
+function runPython(script, args, extraEnv) {
+  return execFileAsync("python3", [script, ...args], {
+    cwd: PROJECT_ROOT,
+    timeout: 30000,
+    env: { ...process.env, ...extraEnv },
+  });
+}
+
+const server = new McpServer({
+  name: "agentic-stack-connector",
+  version: "0.1.0",
+});
+
+server.tool(
+  "recall",
+  "Surface graduated lessons from the agentic-stack portable brain relevant to an intent. Run BEFORE deploy, migration, debug, or refactor tasks.",
+  { intent: z.string().describe("One-line description of the task about to be performed") },
+  async ({ intent }) => {
+    try {
+      const { stdout, stderr } = await runPython(
+        ".agent/tools/recall.py",
+        [intent]
+      );
+      const text = (stdout || "").trim() || "(no lessons found)";
+      return { content: [{ type: "text", text }] };
+    } catch (err) {
+      return {
+        content: [{ type: "text", text: `recall failed: ${err.message}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+server.tool(
+  "memory_reflect",
+  "Log a significant event to the agentic-stack episodic memory. Use after completing a major feature, fixing a bug, making an architectural decision, or encountering a failure.",
+  {
+    skill: z.string().describe("Skill or domain name (e.g. deploy-checklist, git-proxy)"),
+    action: z.string().describe("What was done"),
+    outcome: z.string().describe("What happened — success message or error"),
+    importance: z
+      .number()
+      .min(1)
+      .max(10)
+      .optional()
+      .describe("1–10. 9–10: production incident / data migration. 7–8: deploy, schema change. 5–6: refactor, bug fix. 3–4: routine edit."),
+    fail: z.boolean().optional().describe("Mark this as a failure event"),
+    note: z.string().optional().describe("Free-text context — root cause, why it matters, what to remember"),
+  },
+  async (params) => {
+    const args = [params.skill, params.action, params.outcome];
+    if (params.importance != null) args.push("--importance", String(params.importance));
+    if (params.fail) args.push("--fail");
+    if (params.note) args.push("--note", params.note);
+    try {
+      const { stdout } = await runPython(".agent/tools/memory_reflect.py", args);
+      return {
+        content: [{ type: "text", text: (stdout || "").trim() || "event logged" }],
+      };
+    } catch (err) {
+      return {
+        content: [{ type: "text", text: `memory_reflect failed: ${err.message}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+server.tool(
+  "learn",
+  "Teach the agentic-stack a new rule in one shot (stage + graduate + render). Use when you discover something that should never happen again.",
+  {
+    rule: z.string().describe("The rule, phrased as a principle"),
+    rationale: z.string().describe("Why — include the incident that taught you this"),
+  },
+  async ({ rule, rationale }) => {
+    try {
+      const { stdout } = await runPython(".agent/tools/learn.py", [
+        rule,
+        "--rationale",
+        rationale,
+      ]);
+      return {
+        content: [{ type: "text", text: (stdout || "").trim() || "rule learned" }],
+      };
+    } catch (err) {
+      return {
+        content: [{ type: "text", text: `learn failed: ${err.message}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+server.tool(
+  "agentic_status",
+  "Show a one-screen dashboard of the agentic-stack brain state: episodes, candidates, lessons, failing skills, activity graph.",
+  {},
+  async () => {
+    try {
+      const { stdout } = await runPython(".agent/tools/show.py", []);
+      return {
+        content: [{ type: "text", text: (stdout || "").trim() || "(no status available)" }],
+      };
+    } catch (err) {
+      return {
+        content: [{ type: "text", text: `status failed: ${err.message}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/adapters/opencode/opencode.json
+++ b/adapters/opencode/opencode.json
@@ -1,11 +1,13 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "instructions": ["AGENTS.md", ".agent/AGENTS.md"],
-  "permissions": {
+  "permission": {
     "bash": {
-      "git push --force*": "deny",
+      "*": "ask",
+      "git push --force *": "deny",
       "rm -rf /*": "deny",
-      "git push *": "ask"
+      "git push *": "ask",
+      "git *": "allow"
     },
     "edit": "allow"
   }

--- a/docs/per-harness/gemini-cli.md
+++ b/docs/per-harness/gemini-cli.md
@@ -1,0 +1,131 @@
+# Gemini CLI setup
+
+[Gemini CLI](https://github.com/google-gemini/gemini-cli) reads `GEMINI.md`
+natively as project context and supports MCP servers as a first-class
+extension mechanism. Our adapter layers the portable `.agent/` brain on top
+so you keep one knowledge base even if you later swap harnesses.
+
+## What the adapter installs
+
+- `GEMINI.md` at project root. Points Gemini CLI at `.agent/` for memory,
+  skills, and protocols. Skipped if one already exists that references
+  `.agent/` (for example from another adapter's GEMINI.md).
+- `.gemini/agentic-stack-mcp/server.js` + `package.json` — an MCP server
+  bridge that exposes the portable brain's Python CLI tools (`recall.py`,
+  `memory_reflect.py`, `learn.py`, `show.py`) as MCP tools Gemini CLI can
+  invoke directly.
+- `.gemini/commands/agentic/*.toml` — four custom slash commands:
+  `/agentic:recall`, `/agentic:learn`, `/agentic:status`, `/agentic:reflect`.
+
+## Install
+
+```bash
+# Install Gemini CLI globally
+npm install -g @google/gemini-cli
+
+# Install the adapter
+./install.sh gemini-cli
+
+# Install MCP server Node.js dependencies
+cd .gemini/agentic-stack-mcp && npm install --production && cd ../..
+
+# Register the MCP server in gemini-cli settings (see below)
+gemini
+```
+
+On Windows PowerShell:
+
+```powershell
+npm install -g @google/gemini-cli
+.\install.ps1 gemini-cli C:\path\to\your-project
+cd .gemini\agentic-stack-mcp
+npm install --production
+cd ..\..\..
+gemini
+```
+
+### Register the MCP server
+
+Gemini CLI does not auto-discover MCP servers from the filesystem. After
+running `./install.sh gemini-cli`, add the following entry to your project's
+`.gemini/settings.json` (or `~/.gemini/settings.json` for global access):
+
+```json
+{
+  "mcpServers": {
+    "agentic-stack-connector": {
+      "command": "node",
+      "args": [".gemini/agentic-stack-mcp/server.js"],
+      "env": {
+        "AGENTIC_PROJECT_DIR": "${PWD}"
+      },
+      "timeout": 30000
+    }
+  }
+}
+```
+
+## How it works
+
+- Gemini CLI loads `GEMINI.md` at session start. The adapter file points it
+  at `.agent/AGENTS.md`, `PREFERENCES.md`, `LESSONS.md`, and
+  `permissions.md`.
+- The MCP server (`agentic-stack-connector`) is started by gemini-cli via
+  stdio transport. It spawns `python3` subprocesses to call the brain's
+  Python tools and returns the output as MCP tool results.
+- The model can invoke `recall`, `memory_reflect`, `learn`, and
+  `agentic_status` as MCP tools directly, or users can trigger them via
+  custom slash commands in `.gemini/commands/agentic/`.
+- The adapter intentionally does **not** install lifecycle hooks. Gemini
+  CLI's hooks system is still evolving; manual tool calls (or MCP
+  invocations triggered by the model) remain the stable cross-platform
+  path.
+
+### MCP tools exposed
+
+| Tool | Maps to | Purpose |
+|---|---|---|
+| `recall` | `.agent/tools/recall.py` | Surface graduated lessons for an intent |
+| `memory_reflect` | `.agent/tools/memory_reflect.py` | Log a significant event to episodic memory |
+| `learn` | `.agent/tools/learn.py` | Teach a new rule in one shot |
+| `agentic_status` | `.agent/tools/show.py` | Brain-state dashboard |
+
+### Custom slash commands
+
+| Command | Purpose |
+|---|---|
+| `/agentic:recall <intent>` | Query memory before a task |
+| `/agentic:learn <rule>` | Store a new lesson |
+| `/agentic:status` | Quick brain-state check |
+| `/agentic:reflect <skill> <action> <outcome>` | Log a significant event |
+
+## Verify
+
+```bash
+gemini
+# Inside the session:
+/mcp
+# Expected: agentic-stack-connector (CONNECTED) with 4 tools
+
+/agentic:status
+# Expected: brain-state dashboard output
+
+What lessons do I have about deploying?
+# Expected: model calls recall tool automatically
+```
+
+## Troubleshooting
+
+- **MCP server DISCONNECTED**: Ensure `npm install --production` was run
+  inside `.gemini/agentic-stack-mcp/`. The server needs
+  `@modelcontextprotocol/sdk` and `zod` as runtime dependencies.
+- **"python3 not found"**: The MCP server shells out to `python3`. On
+  stock Windows only `python` or `py` may be on PATH. Create an alias or
+  add `python3` to PATH.
+- **Tools not appearing**: Verify the `mcpServers` entry in
+  `.gemini/settings.json` and the `AGENTIC_PROJECT_DIR` env var.
+- **GEMINI.md not loaded**: Launch `gemini` from the project root where
+  `GEMINI.md` was installed.
+- **Server name has underscore**: Gemini CLI's policy parser splits MCP
+  tool FQNs on the first underscore after `mcp_`. The adapter uses the
+  hyphenated name `agentic-stack-connector` to avoid misparse.

--- a/install.ps1
+++ b/install.ps1
@@ -15,8 +15,9 @@
 #   .\install.ps1                              # bare: list adapters / what
 #                                              # to add
 #
-# adapter-name: claude-code | cursor | windsurf | opencode | openclaw |
-#               hermes | pi | codex | standalone-python | antigravity
+# Core adapters: claude-code | cursor | windsurf | opencode | openclaw |
+# hermes | pi | codex | standalone-python | antigravity
+# Fork adapters (branch: feat/gemini-cli): gemini-cli
 #
 # All real logic lives in harness_manager/ (Python). This script is a
 # thin dispatcher so install.sh and install.ps1 share one backend —

--- a/install.sh
+++ b/install.sh
@@ -16,8 +16,9 @@
 #                                                # (or, if install.json exists,
 #                                                # show what's installable)
 #
-# adapter-name: claude-code | cursor | windsurf | opencode | openclaw |
-#               hermes | pi | codex | standalone-python | antigravity
+# Core adapters: claude-code | cursor | windsurf | opencode | openclaw |
+# hermes | pi | codex | standalone-python | antigravity
+# Fork adapters (branch: feat/gemini-cli): gemini-cli
 #
 # All real logic lives in harness_manager/ (Python). This script is a
 # thin dispatcher so install.sh and install.ps1 share one backend.

--- a/test_gemini_mcp.py
+++ b/test_gemini_mcp.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+"""Validation suite for the gemini-cli adapter.
+
+Run this from the agentic-stack repo root:
+
+    python3 test_gemini_mcp.py
+
+Exit 0 = all tests passed. Non-zero = something is broken.
+
+Tests:
+ 1. adapter.json validates against the harness_manager schema
+ 2. adapter.json name is 'gemini-cli' and is alphanumeric
+ 3. All file entries reference files that exist in the adapter directory
+ 4. GEMINI.md references .agent/ (brain wiring check)
+ 5. GEMINI.md contains recall-before-acting instruction
+ 6. MCP server JS is syntactically valid (node --check)
+ 7. MCP server JS imports @modelcontextprotocol/sdk and zod
+ 8. MCP server JS registers all four tools (recall, memory_reflect, learn, agentic_status)
+ 9. MCP package.json has required dependencies
+10. MCP package.json has engines field requiring node >= 18
+11. All TOML command files have a description and prompt field
+12. TOML command files reference .agent/tools/ scripts
+13. README.md exists and contains install instructions
+14. docs/per-harness/gemini-cli.md exists and contains MCP setup
+15. Install + remove cycle (via harness_manager) is clean
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import shutil
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ADAPTER_DIR = os.path.join(HERE, "adapters", "gemini-cli")
+
+sys.path.insert(0, HERE)
+
+from harness_manager import schema as schema_mod
+
+PASS = "\033[32m✓\033[0m"
+FAIL = "\033[31m✗\033[0m"
+
+_results = []
+
+
+def ok(name):
+    _results.append((True, name))
+    print(f" {PASS} {name}")
+
+
+def fail(name, detail=""):
+    _results.append((False, name))
+    msg = f" {FAIL} {name}"
+    if detail:
+        msg += f"\n   {detail}"
+    print(msg)
+
+
+def section(title):
+    print(f"\n\033[1m{title}\033[0m")
+
+
+# ── tests ──────────────────────────────────────────────────────────────────
+
+def test_adapter_json_validates():
+    manifest_path = os.path.join(ADAPTER_DIR, "adapter.json")
+    try:
+        manifest = schema_mod.validate(manifest_path)
+        ok("adapter.json validates against harness_manager schema")
+    except schema_mod.ManifestError as e:
+        fail("adapter.json validates against harness_manager schema", str(e))
+
+
+def test_adapter_name():
+    manifest_path = os.path.join(ADAPTER_DIR, "adapter.json")
+    try:
+        manifest = schema_mod.validate(manifest_path)
+        name = manifest.get("name", "")
+        if name == "gemini-cli":
+            ok("adapter.json name is 'gemini-cli'")
+        else:
+            fail("adapter.json name is 'gemini-cli'", f"got '{name}'")
+    except schema_mod.ManifestError:
+        fail("adapter.json name is 'gemini-cli'", "manifest invalid")
+
+
+def test_file_entries_exist():
+    manifest_path = os.path.join(ADAPTER_DIR, "adapter.json")
+    try:
+        manifest = schema_mod.validate(manifest_path)
+    except schema_mod.ManifestError:
+        fail("All file entries reference existing files", "manifest invalid")
+        return
+
+    all_exist = True
+    for entry in manifest.get("files", []):
+        src = entry.get("src", "")
+        src_path = os.path.join(ADAPTER_DIR, src)
+        if not os.path.isfile(src_path):
+            fail("All file entries reference existing files", f"missing: {src}")
+            all_exist = False
+            break
+    if all_exist:
+        ok("All file entries reference existing files")
+
+
+def test_gemini_md_references_agent():
+    path = os.path.join(ADAPTER_DIR, "GEMINI.md")
+    if not os.path.isfile(path):
+        fail("GEMINI.md references .agent/", "file not found")
+        return
+    text = open(path).read()
+    if ".agent/" in text:
+        ok("GEMINI.md references .agent/")
+    else:
+        fail("GEMINI.md references .agent/", "no mention of .agent/ found")
+
+
+def test_gemini_md_has_recall_instruction():
+    path = os.path.join(ADAPTER_DIR, "GEMINI.md")
+    if not os.path.isfile(path):
+        fail("GEMINI.md has recall-before-acting instruction", "file not found")
+        return
+    text = open(path).read()
+    if "recall" in text.lower() and "before" in text.lower():
+        ok("GEMINI.md has recall-before-acting instruction")
+    else:
+        fail("GEMINI.md has recall-before-acting instruction",
+             "missing recall-before instruction")
+
+
+def test_mcp_server_js_syntax():
+    path = os.path.join(ADAPTER_DIR, "mcp-server.js")
+    if not os.path.isfile(path):
+        fail("mcp-server.js is syntactically valid", "file not found")
+        return
+    if not shutil.which("node"):
+        ok("mcp-server.js is syntactically valid (skipped: node not found)")
+        return
+    result = subprocess.run(
+        ["node", "--check", path],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        ok("mcp-server.js is syntactically valid")
+    else:
+        fail("mcp-server.js is syntactically valid", result.stderr.strip())
+
+
+def test_mcp_server_imports():
+    path = os.path.join(ADAPTER_DIR, "mcp-server.js")
+    if not os.path.isfile(path):
+        fail("mcp-server.js imports required packages", "file not found")
+        return
+    text = open(path).read()
+    has_mcp = "@modelcontextprotocol/sdk" in text
+    has_zod = '"zod"' in text
+    if has_mcp and has_zod:
+        ok("mcp-server.js imports @modelcontextprotocol/sdk and zod")
+    else:
+        missing = []
+        if not has_mcp:
+            missing.append("@modelcontextprotocol/sdk")
+        if not has_zod:
+            missing.append("zod")
+        fail("mcp-server.js imports @modelcontextprotocol/sdk and zod",
+             f"missing: {', '.join(missing)}")
+
+
+def test_mcp_server_registers_four_tools():
+    path = os.path.join(ADAPTER_DIR, "mcp-server.js")
+    if not os.path.isfile(path):
+        fail("mcp-server.js registers all four tools", "file not found")
+        return
+    text = open(path).read()
+    expected = ["recall", "memory_reflect", "learn", "agentic_status"]
+    missing = [t for t in expected if f'"{t}"' not in text and f"'{t}'" not in text]
+    if not missing:
+        ok("mcp-server.js registers all four tools")
+    else:
+        fail("mcp-server.js registers all four tools",
+             f"missing: {', '.join(missing)}")
+
+
+def test_mcp_package_json_deps():
+    path = os.path.join(ADAPTER_DIR, "mcp-package.json")
+    if not os.path.isfile(path):
+        fail("mcp-package.json has required dependencies", "file not found")
+        return
+    try:
+        pkg = json.loads(open(path).read())
+    except json.JSONDecodeError as e:
+        fail("mcp-package.json has required dependencies", f"invalid JSON: {e}")
+        return
+    deps = pkg.get("dependencies", {})
+    has_mcp = "@modelcontextprotocol/sdk" in deps
+    has_zod = "zod" in deps
+    if has_mcp and has_zod:
+        ok("mcp-package.json has required dependencies")
+    else:
+        missing = []
+        if not has_mcp:
+            missing.append("@modelcontextprotocol/sdk")
+        if not has_zod:
+            missing.append("zod")
+        fail("mcp-package.json has required dependencies",
+             f"missing: {', '.join(missing)}")
+
+
+def test_mcp_package_json_engines():
+    path = os.path.join(ADAPTER_DIR, "mcp-package.json")
+    if not os.path.isfile(path):
+        fail("mcp-package.json has engines field requiring node >= 18",
+             "file not found")
+        return
+    try:
+        pkg = json.loads(open(path).read())
+    except json.JSONDecodeError:
+        fail("mcp-package.json has engines field requiring node >= 18",
+             "invalid JSON")
+        return
+    engines = pkg.get("engines", {})
+    node_ver = engines.get("node", "")
+    if "18" in node_ver:
+        ok("mcp-package.json has engines field requiring node >= 18")
+    else:
+        fail("mcp-package.json has engines field requiring node >= 18",
+             f"got: {node_ver}")
+
+
+def test_toml_commands_have_fields():
+    cmd_dir = os.path.join(ADAPTER_DIR, "commands")
+    if not os.path.isdir(cmd_dir):
+        fail("All TOML command files have description and prompt",
+             "commands/ dir not found")
+        return
+    toml_files = [f for f in os.listdir(cmd_dir) if f.endswith(".toml")]
+    if not toml_files:
+        fail("All TOML command files have description and prompt",
+             "no .toml files found")
+        return
+    all_ok = True
+    for tf in toml_files:
+        text = open(os.path.join(cmd_dir, tf)).read()
+        has_desc = "description" in text
+        has_prompt = "prompt" in text
+        if not (has_desc and has_prompt):
+            missing = []
+            if not has_desc:
+                missing.append("description")
+            if not has_prompt:
+                missing.append("prompt")
+            fail("All TOML command files have description and prompt",
+                 f"{tf}: missing {', '.join(missing)}")
+            all_ok = False
+            break
+    if all_ok:
+        ok("All TOML command files have description and prompt")
+
+
+def test_toml_commands_reference_agent_tools():
+    cmd_dir = os.path.join(ADAPTER_DIR, "commands")
+    if not os.path.isdir(cmd_dir):
+        fail("TOML command files reference .agent/tools/ scripts",
+             "commands/ dir not found")
+        return
+    toml_files = [f for f in os.listdir(cmd_dir) if f.endswith(".toml")]
+    all_ok = True
+    for tf in toml_files:
+        text = open(os.path.join(cmd_dir, tf)).read()
+        if ".agent/tools/" not in text:
+            fail("TOML command files reference .agent/tools/ scripts",
+                 f"{tf}: no .agent/tools/ reference")
+            all_ok = False
+            break
+    if all_ok:
+        ok("TOML command files reference .agent/tools/ scripts")
+
+
+def test_readme_exists_and_has_install():
+    path = os.path.join(ADAPTER_DIR, "README.md")
+    if not os.path.isfile(path):
+        fail("README.md exists and contains install instructions",
+             "file not found")
+        return
+    text = open(path).read()
+    has_install = "install.sh" in text and "gemini-cli" in text
+    if has_install:
+        ok("README.md exists and contains install instructions")
+    else:
+        fail("README.md exists and contains install instructions",
+             "missing install.sh or gemini-cli mention")
+
+
+def test_docs_per_harness_exists():
+    path = os.path.join(HERE, "docs", "per-harness", "gemini-cli.md")
+    if not os.path.isfile(path):
+        fail("docs/per-harness/gemini-cli.md exists and contains MCP setup",
+             "file not found")
+        return
+    text = open(path).read()
+    has_mcp = "mcpServers" in text or "MCP" in text
+    if has_mcp:
+        ok("docs/per-harness/gemini-cli.md exists and contains MCP setup")
+    else:
+        fail("docs/per-harness/gemini-cli.md exists and contains MCP setup",
+             "no MCP mention found")
+
+
+def test_install_remove_cycle():
+    scratch = None
+    try:
+        scratch = tempfile.mkdtemp(prefix="agentic-gemini-test-")
+        from harness_manager import install as install_mod
+        from harness_manager import remove as remove_mod
+        from harness_manager import state as state_mod
+
+        manifest_path = os.path.join(ADAPTER_DIR, "adapter.json")
+        manifest = schema_mod.validate(manifest_path)
+
+        logs = []
+        def log(msg):
+            logs.append(msg)
+
+        shutil.copytree(os.path.join(HERE, ".agent"), os.path.join(scratch, ".agent"))
+
+        install_mod.install(
+            manifest=manifest,
+            target_root=scratch,
+            adapter_dir=ADAPTER_DIR,
+            stack_root=HERE,
+            log=log,
+        )
+
+        state = state_mod.load(scratch)
+        if not state or "gemini-cli" not in (state.get("adapters") or {}):
+            fail("Install + remove cycle is clean", "adapter not recorded in install.json")
+            return
+
+        gemini_md = os.path.join(scratch, "GEMINI.md")
+        mcp_dir = os.path.join(scratch, ".gemini", "agentic-stack-mcp")
+        if not os.path.isfile(gemini_md):
+            fail("Install + remove cycle is clean", "GEMINI.md not created")
+            return
+        if not os.path.isdir(mcp_dir):
+            fail("Install + remove cycle is clean",
+                 ".gemini/agentic-stack-mcp/ not created")
+            return
+
+        remove_mod.remove(
+            target_root=scratch,
+            adapter_name="gemini-cli",
+            yes=True,
+            log=log,
+        )
+
+        state_after = state_mod.load(scratch)
+        adapters_after = (state_after or {}).get("adapters", {})
+        if "gemini-cli" in adapters_after:
+            fail("Install + remove cycle is clean",
+                 "adapter still in install.json after remove")
+            return
+
+        ok("Install + remove cycle is clean")
+
+    except Exception as e:
+        fail("Install + remove cycle is clean", str(e))
+    finally:
+        if scratch:
+            shutil.rmtree(scratch, ignore_errors=True)
+
+
+# ── runner ─────────────────────────────────────────────────────────────────
+
+def main():
+    print("\n\033[1magentic-stack gemini-cli adapter — validation suite\033[0m")
+
+    section("Adapter manifest")
+    test_adapter_json_validates()
+    test_adapter_name()
+    test_file_entries_exist()
+
+    section("GEMINI.md wiring")
+    test_gemini_md_references_agent()
+    test_gemini_md_has_recall_instruction()
+
+    section("MCP server")
+    test_mcp_server_js_syntax()
+    test_mcp_server_imports()
+    test_mcp_server_registers_four_tools()
+
+    section("MCP package")
+    test_mcp_package_json_deps()
+    test_mcp_package_json_engines()
+
+    section("Custom commands")
+    test_toml_commands_have_fields()
+    test_toml_commands_reference_agent_tools()
+
+    section("Documentation")
+    test_readme_exists_and_has_install()
+    test_docs_per_harness_exists()
+
+    section("Install / remove cycle")
+    test_install_remove_cycle()
+
+    passed = sum(1 for ok_, _ in _results if ok_)
+    failed = sum(1 for ok_, _ in _results if not ok_)
+    total = len(_results)
+    print(f"\n\033[1m{passed}/{total} passed, {failed} failed\033[0m")
+    sys.exit(1 if failed else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds the gemini-cli adapter to this fork as a dedicated feature branch that will never be merged into master, keeping master clean for upstream sync.

Changes:
- adapters/gemini-cli/ — full adapter with MCP server bridge, TOML slash commands, and adapter.json manifest
- docs/per-harness/gemini-cli.md — install, MCP setup, troubleshooting
- test_gemini_mcp.py — 15-check validation suite
- adapters/opencode/opencode.json — fix 'permissions' -> 'permission' key
- CHANGELOG.md — [fork/gemini-cli] section (non-semver to avoid upstream version collision)
- README.md — fork feature section for gemini-cli
- ADAPTERS.md — split core vs fork adapter lists by branch
- FORK_SYNC.md — branch strategy and sync rules for agents
- install.sh / install.ps1 — split core vs fork adapter comments