### PR TITLE
feat: add agentic-stack dashboard TUI with trust-console parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable changes to this project.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0] — 2026-05-06
+
+Minor release. Adds a production dashboard TUI for installed agentic-stack
+projects, with the trust-console inspection surface folded into the same
+user-facing entrypoint.
+
+### Added
+- **`agentic-stack dashboard` / `dash`.** Adds a terminal dashboard for project
+  health, installed adapters, doctor checks, harness verification, memory, team
+  brain, skills, managed instances, transfer, and local data exports.
+- **Trust-console parity.** The dashboard includes a per-harness verify matrix,
+  team brain status/init, skills listing, active instance listing,
+  accepted/rejected memory review, and `memory_why()` evidence lookup.
+- **Plain renderer.** `agentic-stack dashboard --plain` and non-TTY fallback
+  produce a script-safe text dashboard for logs, agents, and tests.
+- **Interactive dashboard coverage.** Adds local tests for renderer output,
+  CLI aliases, trust-console parity sections, non-TTY fallback, up/down
+  navigation, refresh, quit, and Enter-open behavior.
+
+### Changed
+- Bare interactive `agentic-stack` / `./install.sh` opens the dashboard when an
+  existing `.agent/install.json` is present. Non-TTY shells keep printing
+  command guidance instead of launching an interactive UI.
+- README, POSIX installer help, and PowerShell installer help now document the
+  dashboard entrypoint.
+
+### Fixed
+- `test_claude_code_hook.py` now works both as a standalone validation script
+  and as a pytest-collected module by providing a real `mod` fixture.
+
+### Migration
+No migration required. Existing projects can run `agentic-stack dashboard`
+after upgrading. Re-run an adapter install only if you want the latest copied
+adapter guidance files in a project.
+
+### Release prep
+- GitHub release notes should use this changelog entry after PR #41 merges.
+- `v0.14.0` already exists on GitHub, so this production dashboard release uses
+  the next minor tag, `v0.15.0`.
+- `Formula/agentic-stack.rb` must be bumped in the usual follow-up after the
+  `v0.15.0` tag exists and the tag tarball sha256 can be computed.
+
 ## [0.13.0] — 2026-05-02
 
 Minor release. Adds an onboarding-style transfer wizard for moving a portable

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ After the first `./install.sh <adapter>`, manage your project with
 verb-style subcommands (works with both `install.sh` and `install.ps1`):
 
 ```bash
-./install.sh dashboard           # interactive dashboard: health, adapters, memory, transfer
+./install.sh dashboard           # TUI dashboard: health, verify, memory, team, skills, instances
 ./install.sh add cursor          # add a second adapter (Claude Code + Cursor in same repo)
 ./install.sh status              # one-screen view: which adapters, brain stats
 ./install.sh doctor              # read-only audit; green / yellow / red per adapter
@@ -366,7 +366,7 @@ harness_manager/                # v0.9.0 manifest-driven Python backend
 ├── state.py                    # install.json read/write with fcntl/msvcrt locking
 ├── doctor.py                   # read-only audit + pre-v0.9 migration synthesis
 ├── remove.py                   # safe uninstall with shared-file detection + ownership handoff
-├── dashboard_tui.py            # project dashboard front door for health/adapters/memory/transfer
+├── dashboard_tui.py            # project dashboard for health/verify/memory/team/skills/instances
 ├── post_install.py             # named built-ins (openclaw_register_workspace)
 ├── manage_tui.py               # interactive menu loop for add/remove/audit
 ├── transfer_tui.py             # onboarding-style memory transfer wizard

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ After the first `./install.sh <adapter>`, manage your project with
 verb-style subcommands (works with both `install.sh` and `install.ps1`):
 
 ```bash
+./install.sh dashboard           # interactive dashboard: health, adapters, memory, transfer
 ./install.sh add cursor          # add a second adapter (Claude Code + Cursor in same repo)
 ./install.sh status              # one-screen view: which adapters, brain stats
 ./install.sh doctor              # read-only audit; green / yellow / red per adapter
@@ -159,8 +160,9 @@ Bare `./install.sh` (no arguments) opens a **multi-select wizard** on
 a fresh project — check every harness you actually use, hit enter,
 each one gets installed. The wizard auto-detects harnesses already on
 disk and pre-checks them. On a project that already has an
-`install.json`, bare `./install.sh` lists what's still installable.
-In non-TTY shells (CI), it prints usage and exits with code 2.
+`install.json`, bare interactive `./install.sh` opens the dashboard.
+In non-TTY shells (CI), it stays script-safe and prints the available
+subcommands instead of opening a TUI.
 
 Upgrading from pre-v0.9? Run `./install.sh doctor` first — it
 synthesizes `install.json` from on-disk adapter signals so the new
@@ -364,6 +366,7 @@ harness_manager/                # v0.9.0 manifest-driven Python backend
 ├── state.py                    # install.json read/write with fcntl/msvcrt locking
 ├── doctor.py                   # read-only audit + pre-v0.9 migration synthesis
 ├── remove.py                   # safe uninstall with shared-file detection + ownership handoff
+├── dashboard_tui.py            # project dashboard front door for health/adapters/memory/transfer
 ├── post_install.py             # named built-ins (openclaw_register_workspace)
 ├── manage_tui.py               # interactive menu loop for add/remove/audit
 ├── transfer_tui.py             # onboarding-style memory transfer wizard

--- a/README.md
+++ b/README.md
@@ -25,22 +25,22 @@ metrics without training a model or sending telemetry.
   <img src="docs/diagram.svg" alt="agentic-stack architecture" width="880"/>
 </p>
 
-### New in v0.13.0 — transfer wizard
+### New in v0.15.0 — dashboard TUI
 
-Minor release. Adds an onboarding-style `agentic-stack transfer` wizard for
-moving a project brain into Codex, Cursor, Windsurf, or a terminal-only
-`AGENTS.md` setup.
+Minor release. Adds `agentic-stack dashboard` as the production front door for
+installed projects: one terminal screen for health, adapters, verification,
+memory, team brain, skills, instances, transfer, and local dashboard exports.
 
-- **Natural-language transfer plans.** Say things like `move my memory into
-  Codex`; the wizard detects targets, memory scopes, and whether to generate a
-  curl command, apply locally, or both.
-- **Portable memory bundles.** Transfers preferences, accepted lessons,
-  skills, working memory, episodic/history logs, and candidate lessons, with
-  SHA-256 verification and secret-like content blocking.
-- **One-line import.** Generated curl/PowerShell bootstraps import the bundle
-  into another project and install the selected adapter files.
-- **Modern Windsurf rules.** Windsurf now gets `.windsurf/rules/agentic-stack.md`
-  while keeping legacy `.windsurfrules` compatibility.
+- **Dashboard command.** Run `agentic-stack dashboard` or `./install.sh dashboard`
+  to open the TUI; use `dash` or `--plain` for a compact script-safe view.
+- **Trust-console parity.** The dashboard includes a per-harness verify matrix,
+  accepted/rejected memory, `memory_why()` evidence lookup, team brain
+  status/init, skills, and managed instances.
+- **Safer installed-project default.** Bare interactive `./install.sh` opens the
+  dashboard once `.agent/install.json` exists; non-TTY shells still print
+  script-safe command guidance instead of launching a TUI.
+- **Production coverage.** Renderer, CLI, parity, non-TTY fallback, and
+  interactive keypress navigation are covered by local tests.
 
 See [CHANGELOG.md](CHANGELOG.md) for the full list.
 
@@ -130,6 +130,7 @@ cd agentic-stack
 
 ```bash
 brew update && brew upgrade agentic-stack
+agentic-stack dashboard
 ```
 
 ### Clone instead?
@@ -155,6 +156,8 @@ verb-style subcommands (works with both `install.sh` and `install.ps1`):
 ./install.sh transfer            # onboarding-style wizard: export/import memory as a curl bridge
 ./install.sh remove cursor       # confirm prompt + delete; no quarantine, no undo
 ```
+
+PowerShell uses the same verbs, for example `.\install.ps1 dashboard`.
 
 Bare `./install.sh` (no arguments) opens a **multi-select wizard** on
 a fresh project — check every harness you actually use, hit enter,

--- a/harness_manager/__init__.py
+++ b/harness_manager/__init__.py
@@ -1,8 +1,9 @@
 """harness_manager — manifest-driven adapter installer for agentic-stack.
 
 This package is the implementation backend for `./install.sh` and `./install.ps1`.
-The user-facing surface is plain verbs: install, add, remove, doctor, status.
+The user-facing surface is plain verbs: install, add, remove, doctor, status,
+dashboard, manage, and transfer.
 The "harness_manager" name is internal only and never appears in CLI help, docs,
 or error messages users see.
 """
-__version__ = "0.13.0"
+__version__ = "0.15.0"

--- a/harness_manager/cli.py
+++ b/harness_manager/cli.py
@@ -1,6 +1,6 @@
 """Argparse dispatcher. install.sh and install.ps1 invoke this.
 
-Verbs (subcommands): add, remove, doctor, status, manage, transfer.
+Verbs (subcommands): add, remove, doctor, status, manage, dashboard, transfer.
 Anything else in first position → treated as an adapter name (existing
 `./install.sh <adapter>` UX preserved).
 """
@@ -19,7 +19,7 @@ from . import status as status_mod
 from . import __version__
 
 
-VERBS = {"add", "remove", "doctor", "status", "manage", "transfer"}
+VERBS = {"add", "remove", "doctor", "status", "manage", "dashboard", "dash", "transfer"}
 
 
 def _stack_root() -> Path:
@@ -247,6 +247,17 @@ def cmd_manage(target: Path) -> int:
     return manage_tui.run(target_root=target, stack_root=_stack_root())
 
 
+def cmd_dashboard(target: Path, plain: bool = False) -> int:
+    """Open the project dashboard.
+
+    `plain` is primarily for non-TTY terminals and tests. The dashboard
+    runner also falls back to plain output automatically when stdin/stdout
+    are not interactive.
+    """
+    from . import dashboard_tui
+    return dashboard_tui.run(target_root=target, stack_root=_stack_root(), plain=plain)
+
+
 def cmd_transfer(args: list[str], target: Path) -> int:
     from . import transfer_tui
     return transfer_tui.run(args, target_root=target, stack_root=_stack_root())
@@ -263,6 +274,8 @@ def cmd_bare(target: Path, wizard_flags: list[str]) -> int:
     """
     doc = state_mod.load(target)
     if doc is not None:
+        if "--yes" not in wizard_flags and sys.stdin.isatty() and sys.stdout.isatty():
+            return cmd_dashboard(target)
         installed = set(doc.get("adapters", {}).keys())
         available = set()
         root = _stack_root() / "adapters"
@@ -273,13 +286,15 @@ def cmd_bare(target: Path, wizard_flags: list[str]) -> int:
         not_installed = sorted(available - installed)
         if not not_installed:
             print(f"all available adapters already installed: {sorted(installed)}")
+            print("open dashboard: ./install.sh dashboard")
             print("run `./install.sh status` for a summary.")
             return 0
         print(f"already installed: {sorted(installed)}")
         print(f"available to add:  {not_installed}")
         print()
         print(f"to add one: ./install.sh add <name>")
-        print(f"or interactively: ./install.sh manage")
+        print(f"open dashboard: ./install.sh dashboard")
+        print(f"or adapter manager only: ./install.sh manage")
         return 0
 
     # No install.json. Pre-v0.9 migration gate: if this is a legacy
@@ -324,6 +339,7 @@ def cmd_bare(target: Path, wizard_flags: list[str]) -> int:
     print("  ./install.sh status      # quick read-only view")
     print("  ./install.sh add <name>  # install another adapter")
     print("  ./install.sh remove <name>  # remove an adapter (with confirm)")
+    print("  ./install.sh dashboard   # interactive project dashboard")
     print("  ./install.sh manage      # interactive TUI for adapter management")
     print("  ./install.sh transfer    # onboarding-style memory transfer wizard")
     return 2
@@ -456,6 +472,19 @@ def main(argv: list[str] | None = None) -> int:
         if verb == "manage":
             target = Path(rest[1]) if len(rest) >= 2 else Path.cwd()
             return cmd_manage(target)
+        if verb in ("dashboard", "dash"):
+            plain = False
+            target_args: list[str] = []
+            for arg in rest[1:]:
+                if arg == "--plain":
+                    plain = True
+                else:
+                    target_args.append(arg)
+            if len(target_args) > 1:
+                print("usage: ./install.sh dashboard [target-dir] [--plain]", file=sys.stderr)
+                return 2
+            target = Path(target_args[0]) if target_args else Path.cwd()
+            return cmd_dashboard(target, plain=plain)
         if verb == "transfer":
             return cmd_transfer(rest[1:], Path.cwd())
 

--- a/harness_manager/dashboard_tui.py
+++ b/harness_manager/dashboard_tui.py
@@ -1,0 +1,435 @@
+"""Interactive agentic-stack dashboard.
+
+This is the human front door for an already-installed project. It keeps the
+existing verb-style commands available for scripts, but gives terminal users a
+single place to inspect health, adapters, memory, transfer, and local dashboard
+exports.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from . import __version__
+from . import doctor as doctor_mod
+from . import schema as schema_mod
+from . import state as state_mod
+from . import status as status_mod
+
+
+SECTIONS = ("Overview", "Adapters", "Doctor", "Memory", "Transfer", "Data")
+
+
+def _logical_path(path: Path | str) -> Path:
+    return Path(os.path.abspath(str(path)))
+
+
+def _count_lines(path: Path) -> int:
+    if not path.is_file():
+        return 0
+    try:
+        with path.open("r", encoding="utf-8", errors="ignore") as handle:
+            return sum(1 for _ in handle)
+    except OSError:
+        return 0
+
+
+def _count_candidate_files(path: Path) -> int:
+    if not path.is_dir():
+        return 0
+    try:
+        return sum(1 for p in path.glob("**/*.json") if p.is_file())
+    except OSError:
+        return 0
+
+
+def _status_from_adapter(status: str) -> str:
+    return {"green": "pass", "yellow": "warn", "red": "fail"}.get(status, "warn")
+
+
+def _status_word(status: str) -> str:
+    return {"pass": "ok", "warn": "warn", "fail": "fail"}.get(status, status)
+
+
+def _check(status: str, label: str, detail: str) -> dict[str, str]:
+    return {"status": status, "label": label, "detail": detail}
+
+
+def _available_adapters(stack_root: Path) -> list[str]:
+    try:
+        return sorted(name for name, _ in schema_mod.discover_all(stack_root) if name != "_shared")
+    except OSError:
+        return []
+
+
+def _adapter_rows(target_root: Path, doc: dict[str, Any] | None) -> list[dict[str, str]]:
+    if not doc:
+        return []
+    rows: list[dict[str, str]] = []
+    for name in sorted((doc.get("adapters") or {}).keys()):
+        entry = doc["adapters"][name]
+        status, details = doctor_mod._audit_adapter(target_root, name, entry)
+        rows.append(
+            {
+                "name": name,
+                "status": _status_from_adapter(status),
+                "detail": details[0] if details else "installed",
+            }
+        )
+    return rows
+
+
+def collect_dashboard(
+    target_root: Path | str,
+    stack_root: Path | str,
+) -> dict[str, Any]:
+    target = _logical_path(target_root)
+    stack = Path(stack_root)
+    agent = target / ".agent"
+    doc = state_mod.load(target)
+    installed = sorted((doc.get("adapters") or {}).keys()) if doc else []
+    available = _available_adapters(stack)
+    missing = sorted(name for name in available if name not in installed)
+
+    checks = [
+        _check("pass" if agent.is_dir() else "fail", ".agent directory", "present" if agent.is_dir() else "missing"),
+        _check(
+            "pass" if (agent / "AGENTS.md").is_file() else "fail",
+            "agent map",
+            ".agent/AGENTS.md present" if (agent / "AGENTS.md").is_file() else ".agent/AGENTS.md missing",
+        ),
+        _check(
+            "pass" if (agent / "memory" / "personal" / "PREFERENCES.md").is_file() else "warn",
+            "personal preferences",
+            "configured" if (agent / "memory" / "personal" / "PREFERENCES.md").is_file() else "not configured",
+        ),
+        _check(
+            "pass" if doc is not None else "warn",
+            "install tracking",
+            ".agent/install.json present" if doc is not None else "install.json missing",
+        ),
+        _check(
+            "pass" if (agent / "memory" / "working" / "REVIEW_QUEUE.md").is_file() else "warn",
+            "review queue",
+            "present" if (agent / "memory" / "working" / "REVIEW_QUEUE.md").is_file() else "missing",
+        ),
+        _check(
+            "pass" if (agent / "memory" / "team").is_dir() else "warn",
+            "team brain",
+            "initialized" if (agent / "memory" / "team").is_dir() else "not initialized",
+        ),
+    ]
+    adapters = _adapter_rows(target, doc)
+    warnings = sum(1 for row in checks + adapters if row["status"] == "warn")
+    failures = sum(1 for row in checks + adapters if row["status"] == "fail")
+    score = max(0, min(100, 100 - failures * 18 - warnings * 7))
+
+    data_dir = agent / "data-layer"
+    dashboard_html = data_dir / "dashboard.html"
+    return {
+        "project": str(target),
+        "version": (doc or {}).get("agentic_stack_version", __version__),
+        "installed_at": (doc or {}).get("installed_at", "?"),
+        "score": score,
+        "warnings": warnings,
+        "failures": failures,
+        "checks": checks,
+        "adapters": adapters,
+        "installed": installed,
+        "available": missing,
+        "brain_summary": status_mod._brain_summary(target),
+        "memory": {
+            "episodes": _count_lines(agent / "memory" / "episodic" / "AGENT_LEARNINGS.jsonl"),
+            "lessons": _count_lines(agent / "memory" / "semantic" / "lessons.jsonl"),
+            "candidates": _count_candidate_files(agent / "memory" / "candidates"),
+        },
+        "transfer": {
+            "ready": agent.is_dir(),
+            "detail": "ready" if agent.is_dir() else ".agent/ missing",
+        },
+        "data": {
+            "dashboard": str(dashboard_html),
+            "exists": dashboard_html.is_file(),
+        },
+    }
+
+
+def _clip(text: object, width: int) -> str:
+    value = str(text)
+    if width <= 0:
+        return ""
+    if len(value) <= width:
+        return value
+    if width == 1:
+        return value[:1]
+    return value[: width - 1] + "~"
+
+
+def _rule(width: int) -> str:
+    return "-" * max(24, min(width, 78))
+
+
+def _plural(count: int, noun: str) -> str:
+    suffix = "" if count == 1 else "s"
+    return f"{count} {noun}{suffix}"
+
+
+def _nav_lines(model: dict[str, Any]) -> list[str]:
+    adapter_count = len(model["installed"])
+    memory = model["memory"]
+    nav = [
+        ("Overview", f"{model['score']}%  {_plural(model['warnings'], 'warning')}"),
+        ("Adapters", f"{adapter_count} installed"),
+        ("Doctor", f"{len(model['checks'])} checks"),
+        ("Memory", f"{_plural(memory['lessons'], 'lesson')}, {_plural(memory['candidates'], 'candidate')}"),
+        ("Transfer", model["transfer"]["detail"]),
+        ("Data", "ready" if model["data"]["exists"] else "not exported"),
+    ]
+    return [f"  {'>' if idx == 0 else ' '} {name:<12} {detail}" for idx, (name, detail) in enumerate(nav)]
+
+
+def _overview_lines(model: dict[str, Any]) -> list[str]:
+    lines = [
+        "Overview",
+        "",
+        "  Brain",
+    ]
+    for check in model["checks"][:6]:
+        lines.append(f"  {_status_word(check['status']):<4} {check['label']:<22} {check['detail']}")
+    lines.extend(["", "  Adapters"])
+    if model["adapters"]:
+        for row in model["adapters"][:5]:
+            lines.append(f"  {_status_word(row['status']):<4} {row['name']:<22} {row['detail']}")
+    else:
+        lines.append("  warn no adapters installed")
+    if model["available"]:
+        lines.append(f"  info {len(model['available'])} adapters available to add")
+    memory = model["memory"]
+    lines.extend(
+        [
+            "",
+            "  Memory",
+            f"  info {_plural(memory['episodes'], 'episode')}, {_plural(memory['lessons'], 'lesson')}, {_plural(memory['candidates'], 'candidate')}",
+            "",
+            "Actions",
+            "  > Open adapter manager",
+            "    Run doctor audit",
+            "    Open transfer wizard",
+        ]
+    )
+    return lines
+
+
+def _adapter_lines(model: dict[str, Any]) -> list[str]:
+    lines = ["Adapters", "", "Installed"]
+    if model["adapters"]:
+        for row in model["adapters"]:
+            lines.append(f"  {_status_word(row['status']):<4} {row['name']:<22} {row['detail']}")
+    else:
+        lines.append("  warn none installed")
+    lines.extend(["", "Available"])
+    if model["available"]:
+        for name in model["available"][:12]:
+            lines.append(f"  add  {name}")
+    else:
+        lines.append("  ok   all available adapters installed")
+    lines.extend(["", "Enter opens the adapter manager."])
+    return lines
+
+
+def _doctor_lines(model: dict[str, Any]) -> list[str]:
+    lines = ["Doctor", ""]
+    for check in model["checks"]:
+        lines.append(f"  {_status_word(check['status']):<4} {check['label']:<22} {check['detail']}")
+    if model["adapters"]:
+        lines.extend(["", "Adapter wiring"])
+        for row in model["adapters"]:
+            lines.append(f"  {_status_word(row['status']):<4} {row['name']:<22} {row['detail']}")
+    return lines
+
+
+def _memory_lines(model: dict[str, Any]) -> list[str]:
+    memory = model["memory"]
+    return [
+        "Memory",
+        "",
+        f"  episodes:   {memory['episodes']}",
+        f"  lessons:    {memory['lessons']}",
+        f"  candidates: {memory['candidates']}",
+        "",
+        "Use semantic lessons for durable rules and candidates for reviewable memory.",
+    ]
+
+
+def _transfer_lines(model: dict[str, Any]) -> list[str]:
+    return [
+        "Transfer",
+        "",
+        f"  status: {model['transfer']['detail']}",
+        "",
+        "Enter opens the transfer wizard.",
+        "Script shortcut: ./install.sh transfer",
+    ]
+
+
+def _data_lines(model: dict[str, Any]) -> list[str]:
+    state = "present" if model["data"]["exists"] else "not generated"
+    return [
+        "Data",
+        "",
+        f"  dashboard.html: {state}",
+        f"  path: {model['data']['dashboard']}",
+        "",
+        "Generate local dashboard exports from the data-layer skill.",
+    ]
+
+
+def _section_lines(section: str, model: dict[str, Any]) -> list[str]:
+    if section == "Adapters":
+        return _adapter_lines(model)
+    if section == "Doctor":
+        return _doctor_lines(model)
+    if section == "Memory":
+        return _memory_lines(model)
+    if section == "Transfer":
+        return _transfer_lines(model)
+    if section == "Data":
+        return _data_lines(model)
+    return _overview_lines(model)
+
+
+def render_plain(
+    target_root: Path | str,
+    stack_root: Path | str,
+    width: int = 78,
+    section: str = "Overview",
+) -> str:
+    model = collect_dashboard(target_root, stack_root)
+    width = max(48, width)
+    header = f"agentic-stack dashboard".ljust(max(1, width - 11)) + f"health {model['score']}%"
+    version = f"agentic-stack v{model['version']}"
+    lines = [
+        _clip(header, width),
+        _clip(f"{model['project']}  {version}", width),
+        _rule(width),
+        "",
+        *_nav_lines(model),
+        "",
+        _rule(width),
+        "",
+        *[_clip(line, width) for line in _section_lines(section, model)],
+        "",
+        _rule(width),
+        "up/down move   enter open   r refresh   q quit",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _addstr(stdscr: Any, y: int, x: int, text: str, attr: int = 0) -> None:
+    try:
+        stdscr.addstr(y, x, text, attr)
+    except Exception:
+        pass
+
+
+def _draw(stdscr: Any, section_idx: int, target_root: Path, stack_root: Path, curses_mod: Any) -> None:
+    model = collect_dashboard(target_root, stack_root)
+    height, width = stdscr.getmaxyx()
+    section = SECTIONS[section_idx]
+    stdscr.erase()
+    _addstr(stdscr, 0, 0, _clip(f"agentic-stack dashboard  health {model['score']}%", width - 1), curses_mod.A_BOLD)
+    _addstr(stdscr, 1, 0, _clip(f"{model['project']}  agentic-stack v{model['version']}", width - 1))
+    _addstr(stdscr, 2, 0, "-" * max(0, width - 1))
+
+    rail_w = min(20, max(14, width // 4))
+    for idx, name in enumerate(SECTIONS):
+        marker = ">" if idx == section_idx else " "
+        detail = ""
+        if name == "Overview":
+            detail = f"{model['score']}%"
+        elif name == "Adapters":
+            detail = str(len(model["installed"]))
+        elif name == "Memory":
+            detail = str(model["memory"]["lessons"])
+        _addstr(stdscr, 4 + idx, 1, _clip(f"{marker} {name:<10} {detail}", rail_w - 2))
+
+    content_x = rail_w + 1
+    content_w = max(10, width - content_x - 1)
+    y = 4
+    for line in _section_lines(section, model):
+        if y >= height - 2:
+            break
+        attr = curses_mod.A_BOLD if line in SECTIONS or line in {"Actions", "Installed", "Available"} else 0
+        _addstr(stdscr, y, content_x, _clip(line, content_w), attr)
+        y += 1
+
+    footer = "up/down move  enter open  r refresh  q quit"
+    _addstr(stdscr, height - 1, 0, _clip(footer, width - 1))
+    stdscr.refresh()
+
+
+def _pause() -> None:
+    try:
+        input("\nPress Enter to return to the dashboard...")
+    except EOFError:
+        pass
+
+
+def _open_section(section: str, target_root: Path, stack_root: Path) -> None:
+    if section in ("Overview", "Adapters"):
+        from . import manage_tui
+
+        manage_tui.run(target_root=target_root, stack_root=stack_root)
+        _pause()
+    elif section == "Doctor":
+        doctor_mod.audit(target_root)
+        _pause()
+    elif section == "Transfer":
+        from . import transfer_tui
+
+        transfer_tui.run([], target_root=target_root, stack_root=stack_root)
+        _pause()
+
+
+def run(target_root: Path | str, stack_root: Path | str, plain: bool = False) -> int:
+    target = _logical_path(target_root)
+    stack = Path(stack_root)
+    if plain or not sys.stdin.isatty() or not sys.stdout.isatty():
+        sys.stdout.write(render_plain(target, stack))
+        return 0
+    try:
+        import curses
+    except ImportError:
+        sys.stdout.write(render_plain(target, stack))
+        return 0
+
+    def _main(stdscr: Any) -> None:
+        try:
+            curses.curs_set(0)
+        except Exception:
+            pass
+        stdscr.keypad(True)
+        section_idx = 0
+        while True:
+            _draw(stdscr, section_idx, target, stack, curses)
+            key = stdscr.getch()
+            if key in (ord("q"), 27):
+                return
+            if key in (ord("j"), curses.KEY_DOWN):
+                section_idx = min(len(SECTIONS) - 1, section_idx + 1)
+            elif key in (ord("k"), curses.KEY_UP):
+                section_idx = max(0, section_idx - 1)
+            elif key == ord("r"):
+                continue
+            elif key in (10, 13, curses.KEY_ENTER):
+                section = SECTIONS[section_idx]
+                curses.endwin()
+                try:
+                    _open_section(section, target, stack)
+                finally:
+                    stdscr.clear()
+
+    curses.wrapper(_main)
+    return 0

--- a/harness_manager/dashboard_tui.py
+++ b/harness_manager/dashboard_tui.py
@@ -2,12 +2,13 @@
 
 This is the human front door for an already-installed project. It keeps the
 existing verb-style commands available for scripts, but gives terminal users a
-single place to inspect health, adapters, memory, transfer, and local dashboard
-exports.
+single place to inspect health, adapters, harness verification, memory, team
+brain, skills, instances, transfer, and local dashboard exports.
 """
 from __future__ import annotations
 
 import os
+import json
 import sys
 from pathlib import Path
 from typing import Any
@@ -19,7 +20,26 @@ from . import state as state_mod
 from . import status as status_mod
 
 
-SECTIONS = ("Overview", "Adapters", "Doctor", "Memory", "Transfer", "Data")
+SECTIONS = (
+    "Overview",
+    "Adapters",
+    "Doctor",
+    "Verify",
+    "Memory",
+    "Team Brain",
+    "Skills",
+    "Instances",
+    "Transfer",
+    "Data",
+)
+
+TEAM_FILES = {
+    "CONVENTIONS.md": "# Team Conventions\n\n",
+    "REVIEW_RULES.md": "# Team Review Rules\n\n",
+    "DEPLOYMENT_LESSONS.md": "# Team Deployment Lessons\n\n",
+    "INCIDENTS.md": "# Team Incident Learnings\n\n",
+    "APPROVED_SKILLS.md": "# Approved Skills\n\n",
+}
 
 
 def _logical_path(path: Path | str) -> Path:
@@ -40,9 +60,70 @@ def _count_candidate_files(path: Path) -> int:
     if not path.is_dir():
         return 0
     try:
-        return sum(1 for p in path.glob("**/*.json") if p.is_file())
+        return sum(1 for p in path.glob("*.json") if p.is_file())
     except OSError:
         return 0
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def _read_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _load_jsonl(path: Path) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    rows: list[dict[str, Any]] = []
+    errors: list[dict[str, Any]] = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return rows, errors
+    for line_no, line in enumerate(lines, 1):
+        raw = line.strip()
+        if not raw:
+            continue
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            errors.append({"path": str(path), "line": line_no, "error": str(exc)})
+            continue
+        if isinstance(payload, dict):
+            rows.append(payload)
+        else:
+            errors.append({"path": str(path), "line": line_no, "error": "row is not an object"})
+    return rows, errors
+
+
+def _candidate_counts(path: Path) -> dict[str, int]:
+    staged = _count_candidate_files(path)
+    graduated = _count_candidate_files(path / "graduated")
+    rejected = _count_candidate_files(path / "rejected")
+    return {
+        "staged": staged,
+        "graduated": graduated,
+        "rejected": rejected,
+        "total": staged + graduated + rejected,
+    }
+
+
+def _load_json_objects(path: Path) -> list[dict[str, Any]]:
+    if not path.is_dir():
+        return []
+    rows: list[dict[str, Any]] = []
+    for item in sorted(path.glob("*.json")):
+        payload = _read_json(item)
+        if isinstance(payload, dict):
+            payload.setdefault("_path", str(item))
+            rows.append(payload)
+    return rows
 
 
 def _status_from_adapter(status: str) -> str:
@@ -64,6 +145,83 @@ def _available_adapters(stack_root: Path) -> list[str]:
         return []
 
 
+def _adapter_file_map(stack_root: Path) -> dict[str, list[str]]:
+    out: dict[str, list[str]] = {}
+    for name, manifest in schema_mod.discover_all(stack_root):
+        files: list[str] = []
+        for item in manifest.get("files") or []:
+            if isinstance(item, dict) and isinstance(item.get("dst"), str):
+                files.append(item["dst"])
+        skills_link = manifest.get("skills_link")
+        if isinstance(skills_link, dict) and isinstance(skills_link.get("dst"), str):
+            files.append(skills_link["dst"])
+        if files:
+            out[name] = files
+    return out
+
+
+def _adapter_text(project: Path, files: list[str]) -> str:
+    parts: list[str] = []
+    for rel in files:
+        path = project / rel
+        if path.is_file():
+            parts.append(_read_text(path))
+        elif path.is_dir():
+            parts.append(str(path))
+    return "\n".join(parts).lower()
+
+
+def _contains(text: str, *needles: str) -> bool:
+    return all(needle.lower() in text for needle in needles)
+
+
+def _verify_status(status: str, detail: str = "") -> dict[str, str]:
+    return {"status": status, "detail": detail}
+
+
+def _verify_rows(target_root: Path, stack_root: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for name, files in sorted(_adapter_file_map(stack_root).items()):
+        missing = [rel for rel in files if not (target_root / rel).exists()]
+        if missing:
+            installed = _verify_status("fail", "missing: " + ", ".join(missing))
+            missing_cell = _verify_status("fail", "adapter file missing")
+            rows.append(
+                {
+                    "harness": name,
+                    "installed": installed,
+                    "memory": missing_cell,
+                    "skills": missing_cell,
+                    "recall": missing_cell,
+                    "reflect": missing_cell,
+                    "permissions": missing_cell,
+                }
+            )
+            continue
+        text = _adapter_text(target_root, files)
+        rows.append(
+            {
+                "harness": name,
+                "installed": _verify_status("pass", ", ".join(files)),
+                "memory": _verify_status(
+                    "pass" if _contains(text, ".agent", "preferences.md", "lessons.md") else "warn",
+                    "memory references present",
+                ),
+                "skills": _verify_status("pass" if "skill" in text else "warn", "skills reference present"),
+                "recall": _verify_status("pass" if "recall.py" in text else "warn", "recall reference present"),
+                "reflect": _verify_status(
+                    "pass" if "memory_reflect.py" in text or "episodic" in text else "warn",
+                    "reflection reference present",
+                ),
+                "permissions": _verify_status(
+                    "pass" if "permissions.md" in text else "warn",
+                    "permissions reference present",
+                ),
+            }
+        )
+    return rows
+
+
 def _adapter_rows(target_root: Path, doc: dict[str, Any] | None) -> list[dict[str, str]]:
     if not doc:
         return []
@@ -81,6 +239,100 @@ def _adapter_rows(target_root: Path, doc: dict[str, Any] | None) -> list[dict[st
     return rows
 
 
+def _load_skill_names(agent: Path) -> tuple[list[str], list[dict[str, Any]]]:
+    rows, errors = _load_jsonl(agent / "skills" / "_manifest.jsonl")
+    names = [str(row.get("name")) for row in rows if isinstance(row.get("name"), str)]
+    if names:
+        return names, errors
+    skills_dir = agent / "skills"
+    if skills_dir.is_dir():
+        names = sorted(p.name for p in skills_dir.iterdir() if p.is_dir() and (p / "SKILL.md").is_file())
+    return names, errors
+
+
+def _team_status(agent: Path) -> dict[str, Any]:
+    team_dir = agent / "memory" / "team"
+    files: dict[str, dict[str, Any]] = {}
+    for name in TEAM_FILES:
+        path = team_dir / name
+        files[name] = {
+            "exists": path.exists(),
+            "path": str(path),
+            "size": path.stat().st_size if path.exists() else 0,
+        }
+    return {"exists": team_dir.is_dir(), "path": str(team_dir), "files": files}
+
+
+def team_init(target_root: Path | str) -> dict[str, Any]:
+    target = _logical_path(target_root)
+    team_dir = target / ".agent" / "memory" / "team"
+    team_dir.mkdir(parents=True, exist_ok=True)
+    created = 0
+    existing = 0
+    for name, content in TEAM_FILES.items():
+        path = team_dir / name
+        if path.exists():
+            existing += 1
+            continue
+        path.write_text(content, encoding="utf-8")
+        created += 1
+    return {"path": str(team_dir), "created": created, "existing": existing, "files": list(TEAM_FILES)}
+
+
+def _instances_status(agent: Path) -> dict[str, Any]:
+    payload = _read_json(agent / "runtime" / "instances.json")
+    if not isinstance(payload, dict):
+        return {"active_instance": None, "count": 0, "items": []}
+    items = payload.get("instances")
+    if not isinstance(items, list):
+        items = payload.get("items")
+    if not isinstance(items, list):
+        items = []
+    return {
+        "active_instance": payload.get("active_instance"),
+        "count": len(items),
+        "items": [item for item in items if isinstance(item, dict)],
+    }
+
+
+def memory_why(identifier: str, target_root: Path | str) -> dict[str, Any]:
+    target = _logical_path(target_root)
+    agent = target / ".agent"
+    lessons, lesson_errors = _load_jsonl(agent / "memory" / "semantic" / "lessons.jsonl")
+    found: dict[str, Any] | None = None
+    for lesson in lessons:
+        aliases = {
+            str(lesson.get("id", "")),
+            str(lesson.get("source_candidate", "")),
+            str(lesson.get("claim", "")),
+        }
+        if identifier in aliases:
+            found = lesson
+            break
+    if found is None:
+        for path in sorted((agent / "memory" / "candidates").glob("**/*.json")):
+            payload = _read_json(path)
+            if isinstance(payload, dict) and identifier in {str(payload.get("id", "")), path.stem}:
+                found = payload
+                break
+    if found is None:
+        return {"found": False, "identifier": identifier, "lesson": None, "evidence": [], "errors": lesson_errors}
+
+    evidence_ids = {str(item) for item in found.get("evidence_ids", [])}
+    episodes, episode_errors = _load_jsonl(agent / "memory" / "episodic" / "AGENT_LEARNINGS.jsonl")
+    evidence = [
+        row for row in episodes
+        if str(row.get("id", "")) in evidence_ids or str(row.get("timestamp", "")) in evidence_ids
+    ]
+    return {
+        "found": True,
+        "identifier": identifier,
+        "lesson": found,
+        "evidence": evidence,
+        "errors": lesson_errors + episode_errors,
+    }
+
+
 def collect_dashboard(
     target_root: Path | str,
     stack_root: Path | str,
@@ -92,6 +344,16 @@ def collect_dashboard(
     installed = sorted((doc.get("adapters") or {}).keys()) if doc else []
     available = _available_adapters(stack)
     missing = sorted(name for name in available if name not in installed)
+    lessons, lesson_errors = _load_jsonl(agent / "memory" / "semantic" / "lessons.jsonl")
+    accepted_lessons = [row for row in lessons if row.get("status") == "accepted"]
+    provisional_lessons = [row for row in lessons if row.get("status") == "provisional"]
+    episodes, episode_errors = _load_jsonl(agent / "memory" / "episodic" / "AGENT_LEARNINGS.jsonl")
+    failed_episodes = [row for row in episodes if row.get("result") == "failure"]
+    candidate_counts = _candidate_counts(agent / "memory" / "candidates")
+    rejected_candidates = _load_json_objects(agent / "memory" / "candidates" / "rejected")
+    skill_names, skill_errors = _load_skill_names(agent)
+    team = _team_status(agent)
+    instances = _instances_status(agent)
 
     checks = [
         _check("pass" if agent.is_dir() else "fail", ".agent directory", "present" if agent.is_dir() else "missing"),
@@ -116,15 +378,18 @@ def collect_dashboard(
             "present" if (agent / "memory" / "working" / "REVIEW_QUEUE.md").is_file() else "missing",
         ),
         _check(
-            "pass" if (agent / "memory" / "team").is_dir() else "warn",
+            "pass" if team["exists"] else "warn",
             "team brain",
-            "initialized" if (agent / "memory" / "team").is_dir() else "not initialized",
+            "initialized" if team["exists"] else "not initialized",
         ),
     ]
+    for err in lesson_errors + episode_errors + skill_errors:
+        checks.append(_check("warn", "data parse", f"{err.get('path')}: {err.get('error')}"))
     adapters = _adapter_rows(target, doc)
+    verify = _verify_rows(target, stack)
     warnings = sum(1 for row in checks + adapters if row["status"] == "warn")
-    failures = sum(1 for row in checks + adapters if row["status"] == "fail")
-    score = max(0, min(100, 100 - failures * 18 - warnings * 7))
+    failed_checks = sum(1 for row in checks + adapters if row["status"] == "fail")
+    score = max(0, min(100, 100 - failed_checks * 18 - warnings * 7))
 
     data_dir = agent / "data-layer"
     dashboard_html = data_dir / "dashboard.html"
@@ -134,17 +399,27 @@ def collect_dashboard(
         "installed_at": (doc or {}).get("installed_at", "?"),
         "score": score,
         "warnings": warnings,
-        "failures": failures,
+        "failures": failed_checks,
         "checks": checks,
         "adapters": adapters,
+        "verify": verify,
         "installed": installed,
         "available": missing,
         "brain_summary": status_mod._brain_summary(target),
         "memory": {
-            "episodes": _count_lines(agent / "memory" / "episodic" / "AGENT_LEARNINGS.jsonl"),
-            "lessons": _count_lines(agent / "memory" / "semantic" / "lessons.jsonl"),
-            "candidates": _count_candidate_files(agent / "memory" / "candidates"),
+            "episodes": len(episodes),
+            "failures": len(failed_episodes),
+            "lessons": len(lessons),
+            "accepted": len(accepted_lessons),
+            "provisional": len(provisional_lessons),
+            "accepted_items": accepted_lessons,
+            "rejected_items": rejected_candidates,
+            "candidates": candidate_counts["total"],
+            "candidate_counts": candidate_counts,
         },
+        "team": team,
+        "skills": {"count": len(skill_names), "names": skill_names},
+        "instances": instances,
         "transfer": {
             "ready": agent.is_dir(),
             "detail": "ready" if agent.is_dir() else ".agent/ missing",
@@ -176,18 +451,24 @@ def _plural(count: int, noun: str) -> str:
     return f"{count} {noun}{suffix}"
 
 
-def _nav_lines(model: dict[str, Any]) -> list[str]:
+def _nav_lines(model: dict[str, Any], selected: str = "Overview") -> list[str]:
     adapter_count = len(model["installed"])
     memory = model["memory"]
+    team_detail = "ready" if model["team"]["exists"] else "missing"
+    instance_detail = f"{model['instances']['count']} total"
     nav = [
         ("Overview", f"{model['score']}%  {_plural(model['warnings'], 'warning')}"),
         ("Adapters", f"{adapter_count} installed"),
         ("Doctor", f"{len(model['checks'])} checks"),
+        ("Verify", f"{len(model['verify'])} harnesses"),
         ("Memory", f"{_plural(memory['lessons'], 'lesson')}, {_plural(memory['candidates'], 'candidate')}"),
+        ("Team Brain", team_detail),
+        ("Skills", _plural(model["skills"]["count"], "skill")),
+        ("Instances", instance_detail),
         ("Transfer", model["transfer"]["detail"]),
         ("Data", "ready" if model["data"]["exists"] else "not exported"),
     ]
-    return [f"  {'>' if idx == 0 else ' '} {name:<12} {detail}" for idx, (name, detail) in enumerate(nav)]
+    return [f"  {'>' if name == selected else ' '} {name:<12} {detail}" for name, detail in nav]
 
 
 def _overview_lines(model: dict[str, Any]) -> list[str]:
@@ -215,6 +496,8 @@ def _overview_lines(model: dict[str, Any]) -> list[str]:
             "",
             "Actions",
             "  > Open adapter manager",
+            "    Inspect verify matrix",
+            "    Inspect team brain",
             "    Run doctor audit",
             "    Open transfer wizard",
         ]
@@ -250,17 +533,106 @@ def _doctor_lines(model: dict[str, Any]) -> list[str]:
     return lines
 
 
+def _cell(status: str) -> str:
+    return {"pass": "ok", "warn": "warn", "fail": "fail"}.get(status, status)
+
+
+def _verify_lines(model: dict[str, Any]) -> list[str]:
+    lines = [
+        "Verify",
+        "",
+        "  harness              install memory skills recall reflect permissions",
+    ]
+    for row in model["verify"]:
+        lines.append(
+            "  "
+            f"{row['harness']:<20}"
+            f"{_cell(row['installed']['status']):<8}"
+            f"{_cell(row['memory']['status']):<7}"
+            f"{_cell(row['skills']['status']):<7}"
+            f"{_cell(row['recall']['status']):<7}"
+            f"{_cell(row['reflect']['status']):<8}"
+            f"{_cell(row['permissions']['status'])}"
+        )
+    return lines
+
+
 def _memory_lines(model: dict[str, Any]) -> list[str]:
     memory = model["memory"]
-    return [
+    counts = memory["candidate_counts"]
+    lines = [
         "Memory",
         "",
         f"  episodes:   {memory['episodes']}",
-        f"  lessons:    {memory['lessons']}",
-        f"  candidates: {memory['candidates']}",
+        f"  failures:   {memory['failures']}",
+        f"  lessons:    {memory['lessons']} ({memory['accepted']} accepted, {memory['provisional']} provisional)",
+        f"  candidates: {memory['candidates']} ({counts['staged']} staged, {counts['graduated']} graduated, {counts['rejected']} rejected)",
         "",
-        "Use semantic lessons for durable rules and candidates for reviewable memory.",
+        "Accepted",
     ]
+    accepted = memory["accepted_items"][:6]
+    if accepted:
+        for lesson in accepted:
+            lines.append(f"  {lesson.get('id', '?')}: {lesson.get('claim', '')}")
+    else:
+        lines.append("  none")
+    lines.append("")
+    lines.append("Rejected")
+    rejected = memory["rejected_items"][:6]
+    if rejected:
+        for item in rejected:
+            lines.append(f"  {item.get('id', '?')}: {item.get('claim', '')}")
+    else:
+        lines.append("  none")
+    lines.extend(["", "Use memory_why(<id>) to inspect supporting evidence."])
+    return lines
+
+
+def _team_lines(model: dict[str, Any]) -> list[str]:
+    team = model["team"]
+    lines = [
+        "Team Brain",
+        "",
+        f"  path: {team['path']}",
+        f"  status: {'initialized' if team['exists'] else 'missing'}",
+        "",
+        "Files",
+    ]
+    for name, meta in team["files"].items():
+        lines.append(f"  {_status_word('pass' if meta['exists'] else 'warn'):<4} {name:<24} {'present' if meta['exists'] else 'missing'}")
+    lines.extend(["", "Enter initializes missing team brain files."])
+    return lines
+
+
+def _skills_lines(model: dict[str, Any]) -> list[str]:
+    lines = ["Skills", "", f"  loaded: {model['skills']['count']}", ""]
+    names = model["skills"]["names"]
+    if names:
+        for name in names[:16]:
+            lines.append(f"  - {name}")
+    else:
+        lines.append("  none")
+    return lines
+
+
+def _instances_lines(model: dict[str, Any]) -> list[str]:
+    inst = model["instances"]
+    lines = [
+        "Instances",
+        "",
+        f"  active: {inst.get('active_instance') or 'none'}",
+        f"  count:  {inst.get('count', 0)}",
+        "",
+    ]
+    items = inst.get("items", [])
+    if items:
+        for item in items[:12]:
+            lines.append(
+                f"  {item.get('id', '?'):<18} state={item.get('state', '?')} pid={item.get('worker_pid') or '-'}"
+            )
+    else:
+        lines.append("  no managed instances")
+    return lines
 
 
 def _transfer_lines(model: dict[str, Any]) -> list[str]:
@@ -291,8 +663,16 @@ def _section_lines(section: str, model: dict[str, Any]) -> list[str]:
         return _adapter_lines(model)
     if section == "Doctor":
         return _doctor_lines(model)
+    if section == "Verify":
+        return _verify_lines(model)
     if section == "Memory":
         return _memory_lines(model)
+    if section == "Team Brain":
+        return _team_lines(model)
+    if section == "Skills":
+        return _skills_lines(model)
+    if section == "Instances":
+        return _instances_lines(model)
     if section == "Transfer":
         return _transfer_lines(model)
     if section == "Data":
@@ -308,6 +688,7 @@ def render_plain(
 ) -> str:
     model = collect_dashboard(target_root, stack_root)
     width = max(48, width)
+    selected = section if section in SECTIONS else "Overview"
     header = f"agentic-stack dashboard".ljust(max(1, width - 11)) + f"health {model['score']}%"
     version = f"agentic-stack v{model['version']}"
     lines = [
@@ -315,11 +696,11 @@ def render_plain(
         _clip(f"{model['project']}  {version}", width),
         _rule(width),
         "",
-        *_nav_lines(model),
+        *_nav_lines(model, selected),
         "",
         _rule(width),
         "",
-        *[_clip(line, width) for line in _section_lines(section, model)],
+        *[_clip(line, width) for line in _section_lines(selected, model)],
         "",
         _rule(width),
         "up/down move   enter open   r refresh   q quit",
@@ -351,8 +732,16 @@ def _draw(stdscr: Any, section_idx: int, target_root: Path, stack_root: Path, cu
             detail = f"{model['score']}%"
         elif name == "Adapters":
             detail = str(len(model["installed"]))
+        elif name == "Verify":
+            detail = str(len(model["verify"]))
         elif name == "Memory":
             detail = str(model["memory"]["lessons"])
+        elif name == "Team Brain":
+            detail = "ok" if model["team"]["exists"] else "!"
+        elif name == "Skills":
+            detail = str(model["skills"]["count"])
+        elif name == "Instances":
+            detail = str(model["instances"]["count"])
         _addstr(stdscr, 4 + idx, 1, _clip(f"{marker} {name:<10} {detail}", rail_w - 2))
 
     content_x = rail_w + 1
@@ -377,6 +766,29 @@ def _pause() -> None:
         pass
 
 
+def _show_memory_why(target_root: Path) -> None:
+    try:
+        identifier = input("Lesson/candidate id to explain (blank to cancel): ").strip()
+    except EOFError:
+        return
+    if not identifier:
+        return
+    payload = memory_why(identifier, target_root)
+    if not payload["found"]:
+        print(f"not found: {identifier}")
+        _pause()
+        return
+    lesson = payload["lesson"] or {}
+    print()
+    print(f"id: {lesson.get('id', identifier)}")
+    print(f"claim: {lesson.get('claim', '')}")
+    print(f"status: {lesson.get('status', '?')}")
+    print(f"evidence: {len(payload['evidence'])}")
+    for row in payload["evidence"][:5]:
+        print(f"- {row.get('id') or row.get('timestamp') or '?'} {row.get('action') or row.get('event') or ''}")
+    _pause()
+
+
 def _open_section(section: str, target_root: Path, stack_root: Path) -> None:
     if section in ("Overview", "Adapters"):
         from . import manage_tui
@@ -385,6 +797,13 @@ def _open_section(section: str, target_root: Path, stack_root: Path) -> None:
         _pause()
     elif section == "Doctor":
         doctor_mod.audit(target_root)
+        _pause()
+    elif section == "Memory":
+        _show_memory_why(target_root)
+    elif section == "Team Brain":
+        result = team_init(target_root)
+        print(f"team brain initialized: created={result['created']} existing={result['existing']}")
+        print(result["path"])
         _pause()
     elif section == "Transfer":
         from . import transfer_tui

--- a/harness_manager/dashboard_tui.py
+++ b/harness_manager/dashboard_tui.py
@@ -812,6 +812,33 @@ def _open_section(section: str, target_root: Path, stack_root: Path) -> None:
         _pause()
 
 
+def _run_interactive(stdscr: Any, target: Path, stack: Path, curses_mod: Any) -> None:
+    try:
+        curses_mod.curs_set(0)
+    except Exception:
+        pass
+    stdscr.keypad(True)
+    section_idx = 0
+    while True:
+        _draw(stdscr, section_idx, target, stack, curses_mod)
+        key = stdscr.getch()
+        if key in (ord("q"), 27):
+            return
+        if key in (ord("j"), curses_mod.KEY_DOWN):
+            section_idx = min(len(SECTIONS) - 1, section_idx + 1)
+        elif key in (ord("k"), curses_mod.KEY_UP):
+            section_idx = max(0, section_idx - 1)
+        elif key == ord("r"):
+            continue
+        elif key in (10, 13, curses_mod.KEY_ENTER):
+            section = SECTIONS[section_idx]
+            curses_mod.endwin()
+            try:
+                _open_section(section, target, stack)
+            finally:
+                stdscr.clear()
+
+
 def run(target_root: Path | str, stack_root: Path | str, plain: bool = False) -> int:
     target = _logical_path(target_root)
     stack = Path(stack_root)
@@ -825,30 +852,7 @@ def run(target_root: Path | str, stack_root: Path | str, plain: bool = False) ->
         return 0
 
     def _main(stdscr: Any) -> None:
-        try:
-            curses.curs_set(0)
-        except Exception:
-            pass
-        stdscr.keypad(True)
-        section_idx = 0
-        while True:
-            _draw(stdscr, section_idx, target, stack, curses)
-            key = stdscr.getch()
-            if key in (ord("q"), 27):
-                return
-            if key in (ord("j"), curses.KEY_DOWN):
-                section_idx = min(len(SECTIONS) - 1, section_idx + 1)
-            elif key in (ord("k"), curses.KEY_UP):
-                section_idx = max(0, section_idx - 1)
-            elif key == ord("r"):
-                continue
-            elif key in (10, 13, curses.KEY_ENTER):
-                section = SECTIONS[section_idx]
-                curses.endwin()
-                try:
-                    _open_section(section, target, stack)
-                finally:
-                    stdscr.clear()
+        _run_interactive(stdscr, target, stack, curses)
 
     curses.wrapper(_main)
     return 0

--- a/install.ps1
+++ b/install.ps1
@@ -10,10 +10,12 @@
 #                                              # remove an installed adapter
 #   .\install.ps1 doctor [target-dir]          # read-only audit
 #   .\install.ps1 status [target-dir]          # one-screen view
+#   .\install.ps1 dashboard [target-dir]       # interactive project dashboard
 #   .\install.ps1 manage [target-dir]          # interactive adapter TUI
 #   .\install.ps1 transfer                     # memory transfer wizard
-#   .\install.ps1                              # bare: list adapters / what
-#                                              # to add
+#   .\install.ps1                              # bare: install wizard for fresh
+#                                              # projects, dashboard for already
+#                                              # installed interactive projects
 #
 # adapter-name: claude-code | cursor | windsurf | opencode | openclaw |
 #               hermes | pi | codex | standalone-python | antigravity

--- a/install.sh
+++ b/install.sh
@@ -10,11 +10,12 @@
 #                                                # remove an installed adapter
 #   ./install.sh doctor [target-dir]             # read-only audit
 #   ./install.sh status [target-dir]             # one-screen view
+#   ./install.sh dashboard [target-dir]          # interactive project dashboard
 #   ./install.sh manage [target-dir]             # interactive adapter TUI
 #   ./install.sh transfer                        # memory transfer wizard
-#   ./install.sh                                 # bare: list available adapters
-#                                                # (or, if install.json exists,
-#                                                # show what's installable)
+#   ./install.sh                                 # bare: install wizard for fresh
+#                                                # projects, dashboard for already
+#                                                # installed interactive projects
 #
 # adapter-name: claude-code | cursor | windsurf | opencode | openclaw |
 #               hermes | pi | codex | standalone-python | antigravity

--- a/test_claude_code_hook.py
+++ b/test_claude_code_hook.py
@@ -110,6 +110,16 @@ def _load_hook():
     spec.loader.exec_module(mod)
     return mod
 
+try:
+    import pytest
+except ImportError:
+    pytest = None
+
+if pytest is not None:
+    @pytest.fixture
+    def mod():
+        return _load_hook()
+
 # ── tests ─────────────────────────────────────────────────────────────────────
 
 def test_hook_exists():
@@ -120,7 +130,7 @@ def test_hook_exists():
         fail("claude_code_post_tool.py NOT FOUND",
              f"expected: {HOOK_SCRIPT}")
 
-def test_hook_imports():
+def _check_hook_imports():
     section("2. Import / path resolution")
     try:
         mod = _load_hook()
@@ -129,6 +139,9 @@ def test_hook_imports():
     except Exception as e:
         fail("hook import failed", str(e))
         return None
+
+def test_hook_imports():
+    _check_hook_imports()
 
 def test_empty_stdin():
     section("3. Empty stdin — graceful fallback")
@@ -453,7 +466,7 @@ def main():
     print(f"agent dir:    {AGENT_DIR}")
 
     test_hook_exists()
-    mod = test_hook_imports()
+    mod = _check_hook_imports()
     if mod is None:
         print("\n\033[31mCannot continue — hook did not import.\033[0m")
         sys.exit(1)

--- a/test_dashboard_tui.py
+++ b/test_dashboard_tui.py
@@ -1,0 +1,123 @@
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+
+
+class DashboardTuiTest(unittest.TestCase):
+    def make_project(self, root: Path) -> None:
+        agent = root / ".agent"
+        (agent / "memory" / "personal").mkdir(parents=True)
+        (agent / "memory" / "semantic").mkdir(parents=True)
+        (agent / "memory" / "episodic").mkdir(parents=True)
+        (agent / "memory" / "candidates").mkdir(parents=True)
+        (agent / "skills" / "example").mkdir(parents=True)
+        (agent / "protocols").mkdir(parents=True)
+        (agent / "AGENTS.md").write_text("# Agentic Stack\n", encoding="utf-8")
+        (agent / "memory" / "personal" / "PREFERENCES.md").write_text(
+            "# Preferences\n\n- Keep output direct.\n",
+            encoding="utf-8",
+        )
+        (agent / "memory" / "semantic" / "lessons.jsonl").write_text(
+            json.dumps({"id": "lesson_1", "status": "accepted", "claim": "Use local checks."}) + "\n",
+            encoding="utf-8",
+        )
+        (agent / "memory" / "episodic" / "AGENT_LEARNINGS.jsonl").write_text(
+            json.dumps({"event": "installed"}) + "\n",
+            encoding="utf-8",
+        )
+        (agent / "skills" / "example" / "SKILL.md").write_text(
+            "# Example\n",
+            encoding="utf-8",
+        )
+        (agent / "install.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "agentic_stack_version": "0.13.0",
+                    "installed_at": "2026-05-06T00:00:00Z",
+                    "adapters": {
+                        "codex": {
+                            "files_written": [],
+                            "files_overwritten": [],
+                            "file_results": [],
+                            "post_install_results": [],
+                        }
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    def run_cli(self, cwd: Path, *args: str):
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(ROOT)
+        env["AGENTIC_STACK_ROOT"] = str(ROOT)
+        return subprocess.run(
+            ["python3", "-m", "harness_manager.cli", *args],
+            cwd=cwd,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_plain_dashboard_renders_main_sections(self):
+        from harness_manager import dashboard_tui
+
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            self.make_project(project)
+
+            rendered = dashboard_tui.render_plain(project, ROOT, width=76)
+
+        self.assertIn("agentic-stack dashboard", rendered)
+        self.assertIn("> Overview", rendered)
+        self.assertIn("Adapters", rendered)
+        self.assertIn("Doctor", rendered)
+        self.assertIn("Memory", rendered)
+        self.assertIn("Transfer", rendered)
+        self.assertIn("Data", rendered)
+        self.assertIn("codex", rendered)
+        self.assertIn("1 lesson", rendered)
+
+    def test_dashboard_cli_plain_output(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            self.make_project(project)
+
+            result = self.run_cli(project, "dashboard", str(project), "--plain")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("agentic-stack dashboard", result.stdout)
+        self.assertIn("codex", result.stdout)
+
+    def test_dash_alias_plain_output(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            self.make_project(project)
+
+            result = self.run_cli(project, "dash", str(project), "--plain")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("agentic-stack dashboard", result.stdout)
+
+    def test_bare_installed_project_stays_script_safe_without_tty(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            self.make_project(project)
+
+            result = self.run_cli(project)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("open dashboard", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_dashboard_tui.py
+++ b/test_dashboard_tui.py
@@ -16,23 +16,72 @@ class DashboardTuiTest(unittest.TestCase):
         (agent / "memory" / "semantic").mkdir(parents=True)
         (agent / "memory" / "episodic").mkdir(parents=True)
         (agent / "memory" / "candidates").mkdir(parents=True)
+        (agent / "memory" / "candidates" / "graduated").mkdir(parents=True)
+        (agent / "memory" / "candidates" / "rejected").mkdir(parents=True)
+        (agent / "memory" / "team").mkdir(parents=True)
+        (agent / "runtime").mkdir(parents=True)
         (agent / "skills" / "example").mkdir(parents=True)
         (agent / "protocols").mkdir(parents=True)
+        (root / ".agents" / "skills").mkdir(parents=True)
+        (root / "AGENTS.md").write_text(
+            "Use .agent/memory/personal/PREFERENCES.md and .agent/memory/semantic/LESSONS.md.\n"
+            "Load skills, call .agent/tools/recall.py, log with .agent/tools/memory_reflect.py, "
+            "and follow .agent/protocols/permissions.md.\n",
+            encoding="utf-8",
+        )
         (agent / "AGENTS.md").write_text("# Agentic Stack\n", encoding="utf-8")
+        (agent / "protocols" / "permissions.md").write_text("# Permissions\n", encoding="utf-8")
         (agent / "memory" / "personal" / "PREFERENCES.md").write_text(
             "# Preferences\n\n- Keep output direct.\n",
             encoding="utf-8",
         )
         (agent / "memory" / "semantic" / "lessons.jsonl").write_text(
-            json.dumps({"id": "lesson_1", "status": "accepted", "claim": "Use local checks."}) + "\n",
+            json.dumps(
+                {
+                    "id": "lesson_1",
+                    "status": "accepted",
+                    "claim": "Use local checks.",
+                    "evidence_ids": ["episode_1"],
+                }
+            )
+            + "\n"
+            + json.dumps({"id": "lesson_2", "status": "provisional", "claim": "Review before deploy."})
+            + "\n",
             encoding="utf-8",
         )
         (agent / "memory" / "episodic" / "AGENT_LEARNINGS.jsonl").write_text(
-            json.dumps({"event": "installed"}) + "\n",
+            json.dumps({"id": "episode_1", "event": "installed", "result": "success"}) + "\n",
+            encoding="utf-8",
+        )
+        (agent / "memory" / "candidates" / "candidate_1.json").write_text(
+            json.dumps({"id": "candidate_1", "claim": "Prefer the dashboard.", "status": "staged"}) + "\n",
+            encoding="utf-8",
+        )
+        (agent / "memory" / "candidates" / "rejected" / "candidate_2.json").write_text(
+            json.dumps({"id": "candidate_2", "claim": "Use a hidden command.", "status": "rejected"}) + "\n",
             encoding="utf-8",
         )
         (agent / "skills" / "example" / "SKILL.md").write_text(
             "# Example\n",
+            encoding="utf-8",
+        )
+        (agent / "skills" / "_manifest.jsonl").write_text(
+            json.dumps({"name": "example", "description": "Example skill"}) + "\n",
+            encoding="utf-8",
+        )
+        for name in ("CONVENTIONS.md", "REVIEW_RULES.md", "DEPLOYMENT_LESSONS.md", "INCIDENTS.md", "APPROVED_SKILLS.md"):
+            (agent / "memory" / "team" / name).write_text(f"# {name}\n", encoding="utf-8")
+        (agent / "runtime" / "instances.json").write_text(
+            json.dumps(
+                {
+                    "active_instance": "worker-a",
+                    "instances": [
+                        {"id": "worker-a", "state": "running", "worker_pid": 1234},
+                        {"id": "worker-b", "state": "stopped", "worker_pid": None},
+                    ],
+                }
+            )
+            + "\n",
             encoding="utf-8",
         )
         (agent / "install.json").write_text(
@@ -81,11 +130,73 @@ class DashboardTuiTest(unittest.TestCase):
         self.assertIn("> Overview", rendered)
         self.assertIn("Adapters", rendered)
         self.assertIn("Doctor", rendered)
+        self.assertIn("Verify", rendered)
         self.assertIn("Memory", rendered)
+        self.assertIn("Team Brain", rendered)
+        self.assertIn("Skills", rendered)
+        self.assertIn("Instances", rendered)
         self.assertIn("Transfer", rendered)
         self.assertIn("Data", rendered)
         self.assertIn("codex", rendered)
-        self.assertIn("1 lesson", rendered)
+        self.assertIn("2 lessons", rendered)
+
+    def test_verify_section_renders_harness_matrix(self):
+        from harness_manager import dashboard_tui
+
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            self.make_project(project)
+
+            rendered = dashboard_tui.render_plain(project, ROOT, width=96, section="Verify")
+
+        self.assertIn("Verify", rendered)
+        self.assertIn("harness", rendered)
+        self.assertIn("install", rendered)
+        self.assertIn("memory", rendered)
+        self.assertIn("skills", rendered)
+        self.assertIn("recall", rendered)
+        self.assertIn("reflect", rendered)
+        self.assertIn("permissions", rendered)
+        self.assertIn("codex", rendered)
+
+    def test_team_skills_instances_sections_render(self):
+        from harness_manager import dashboard_tui
+
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            self.make_project(project)
+
+            team = dashboard_tui.render_plain(project, ROOT, width=96, section="Team Brain")
+            skills = dashboard_tui.render_plain(project, ROOT, width=96, section="Skills")
+            instances = dashboard_tui.render_plain(project, ROOT, width=96, section="Instances")
+
+        self.assertIn("Team Brain", team)
+        self.assertIn("CONVENTIONS.md", team)
+        self.assertIn("APPROVED_SKILLS.md", team)
+        self.assertIn("Skills", skills)
+        self.assertIn("example", skills)
+        self.assertIn("Instances", instances)
+        self.assertIn("worker-a", instances)
+        self.assertIn("running", instances)
+
+    def test_memory_section_renders_learned_rejected_and_why(self):
+        from harness_manager import dashboard_tui
+
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            self.make_project(project)
+
+            rendered = dashboard_tui.render_plain(project, ROOT, width=96, section="Memory")
+            why = dashboard_tui.memory_why("lesson_1", project)
+
+        self.assertIn("Accepted", rendered)
+        self.assertIn("lesson_1", rendered)
+        self.assertIn("candidates: 2 (1 staged, 0 graduated, 1 rejected)", rendered)
+        self.assertIn("Rejected", rendered)
+        self.assertIn("candidate_2", rendered)
+        self.assertTrue(why["found"])
+        self.assertEqual(why["lesson"]["id"], "lesson_1")
+        self.assertEqual(len(why["evidence"]), 1)
 
     def test_dashboard_cli_plain_output(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/test_dashboard_tui.py
+++ b/test_dashboard_tui.py
@@ -9,6 +9,58 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent
 
 
+class FakeCurses:
+    A_BOLD = 1
+    KEY_DOWN = 258
+    KEY_UP = 259
+    KEY_ENTER = 343
+
+    def __init__(self):
+        self.cursor_values = []
+        self.endwin_count = 0
+
+    def curs_set(self, value):
+        self.cursor_values.append(value)
+
+    def endwin(self):
+        self.endwin_count += 1
+
+
+class FakeScreen:
+    def __init__(self, keys, height=32, width=100):
+        self.keys = list(keys)
+        self.height = height
+        self.width = width
+        self.keypad_enabled = None
+        self.clear_count = 0
+        self.current = {}
+        self.snapshots = []
+
+    def getmaxyx(self):
+        return self.height, self.width
+
+    def keypad(self, enabled):
+        self.keypad_enabled = enabled
+
+    def erase(self):
+        self.current = {}
+
+    def clear(self):
+        self.clear_count += 1
+        self.current = {}
+
+    def addstr(self, y, x, text, attr=0):
+        self.current[(y, x)] = text
+
+    def refresh(self):
+        self.snapshots.append(dict(self.current))
+
+    def getch(self):
+        if self.keys:
+            return self.keys.pop(0)
+        return ord("q")
+
+
 class DashboardTuiTest(unittest.TestCase):
     def make_project(self, root: Path) -> None:
         agent = root / ".agent"
@@ -228,6 +280,54 @@ class DashboardTuiTest(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("open dashboard", result.stdout)
+
+    def test_interactive_dashboard_keypress_navigation(self):
+        from harness_manager import dashboard_tui
+
+        curses = FakeCurses()
+        screen = FakeScreen(
+            [
+                curses.KEY_DOWN,
+                curses.KEY_DOWN,
+                ord("r"),
+                curses.KEY_UP,
+                ord("q"),
+            ]
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            self.make_project(project)
+
+            dashboard_tui._run_interactive(screen, project, ROOT, curses)
+
+        self.assertEqual(curses.cursor_values, [0])
+        self.assertTrue(screen.keypad_enabled)
+        headings = [snapshot.get((4, 21)) for snapshot in screen.snapshots]
+        self.assertEqual(headings, ["Overview", "Adapters", "Doctor", "Doctor", "Adapters"])
+
+    def test_interactive_dashboard_enter_opens_selected_section(self):
+        from harness_manager import dashboard_tui
+
+        curses = FakeCurses()
+        screen = FakeScreen([curses.KEY_DOWN, curses.KEY_ENTER, ord("q")])
+        opened = []
+        original_open_section = dashboard_tui._open_section
+
+        def fake_open_section(section, target_root, stack_root):
+            opened.append((section, target_root, stack_root))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            self.make_project(project)
+            try:
+                dashboard_tui._open_section = fake_open_section
+                dashboard_tui._run_interactive(screen, project, ROOT, curses)
+            finally:
+                dashboard_tui._open_section = original_open_section
+
+        self.assertEqual(opened, [("Adapters", project, ROOT)])
+        self.assertEqual(curses.endwin_count, 1)
+        self.assertEqual(screen.clear_count, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Status
Ready for production review/merge. The source branch `codex/tui-dashboard` contains the dashboard TUI, trust-console parity, and release-prep metadata for `v0.15.0`.

`v0.14.0` already exists on GitHub, so this dashboard release is prepared as the next minor version, `v0.15.0`. `Formula/agentic-stack.rb` intentionally stays on the last real tarball until after the `v0.15.0` tag exists and the new tarball sha256 can be computed.

## File changes included
- `harness_manager/dashboard_tui.py`: dashboard TUI implementation with trust-console parity and testable interactive loop
- `harness_manager/cli.py`: `dashboard` / `dash` command wiring and bare interactive dashboard routing
- `harness_manager/__init__.py`: package version bumped to `0.15.0`
- `install.sh`: command help for the dashboard entrypoint
- `install.ps1`: PowerShell help parity for the dashboard entrypoint
- `README.md`: production-facing dashboard docs and upgrade command
- `CHANGELOG.md`: `v0.15.0` release notes and GitHub release prep notes
- `test_dashboard_tui.py`: renderer, CLI, parity, and interactive keypress navigation coverage
- `test_claude_code_hook.py`: pytest fixture compatibility fix

## Summary
- add `./install.sh dashboard` / `agentic-stack dashboard` / `dash` as the agentic-stack TUI front door
- include trust-console functionality in this same dashboard PR: verify matrix, team brain status/init, skills listing, instances listing, accepted/rejected memory, and `memory_why()` evidence lookup
- keep existing script commands available for automation and route bare interactive `./install.sh` to the dashboard when `.agent/install.json` already exists
- keep non-TTY behavior script-safe instead of opening a TUI
- add automated dashboard keypress coverage for up/down movement, refresh, quit, and Enter-open behavior without requiring a real terminal session
- prepare production release docs for `v0.15.0`; Formula bump remains the normal post-tag follow-up

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile harness_manager/dashboard_tui.py harness_manager/cli.py harness_manager/__init__.py test_dashboard_tui.py test_claude_code_hook.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m harness_manager.cli dashboard --plain`
- `bash -n install.sh`
- `ruby -c Formula/agentic-stack.rb` -> Syntax OK
- PowerShell parse check skipped locally because `pwsh` is not installed
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest test_dashboard_tui.py test_claude_code_hook.py` -> 24 passed
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest` -> 65 passed
- `PYTHONDONTWRITEBYTECODE=1 python3 -m harness_manager.schema`

CI was intentionally not run. All commits include `[skip ci]`.