### PR TITLE
Fix upgrade path and skill manifest drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **`agentic-stack upgrade`.** Adds a safe project migration verb that refreshes
+  skeleton-owned `.agent` infrastructure, copies new skills, supports
+  `--dry-run`/`--yes`, and leaves adapter configs plus user memory untouched.
+- **`agentic-stack sync-manifest`.** Rebuilds `.agent/skills/_manifest.jsonl`
+  from installed `SKILL.md` frontmatter so copied skills can trigger correctly.
+
+### Fixed
+- Install/add now re-sync the skill manifest when a project already has
+  `.agent/skills`, preventing `_index.md` / `_manifest.jsonl` drift.
+- `doctor` now warns when Claude Code hook commands reference missing `.agent`
+  Python files or when hook scripts are present but not wired in
+  `.claude/settings.json`.
+
 ## [0.15.0] — 2026-05-06
 
 Minor release. Adds a production dashboard TUI for installed agentic-stack

--- a/README.md
+++ b/README.md
@@ -154,6 +154,9 @@ verb-style subcommands (works with both `install.sh` and `install.ps1`):
 ./install.sh doctor              # read-only audit; green / yellow / red per adapter
 ./install.sh manage              # interactive TUI: header pane + menu loop for add/remove/audit
 ./install.sh transfer            # onboarding-style wizard: export/import memory as a curl bridge
+./install.sh upgrade --dry-run   # preview safe .agent infrastructure refresh
+./install.sh upgrade --yes       # copy latest harness/memory/tools + new skills
+./install.sh sync-manifest       # rebuild .agent/skills/_manifest.jsonl from SKILL.md frontmatter
 ./install.sh remove cursor       # confirm prompt + delete; no quarantine, no undo
 ```
 
@@ -171,6 +174,16 @@ Upgrading from pre-v0.9? Run `./install.sh doctor` first — it
 synthesizes `install.json` from on-disk adapter signals so the new
 backend can track them. Installing on top without migration would
 orphan the prior installs.
+
+Upgrading an already-installed project after `brew upgrade`? Run
+`agentic-stack upgrade --dry-run` in the project first, then
+`agentic-stack upgrade --yes` to refresh only skeleton-owned `.agent`
+infrastructure (`harness/**/*.py`, top-level `memory/*.py`, `tools/*.py`,
+the generated skill index, and new skill directories). It does not rewrite
+`CLAUDE.md`, `.claude/settings.json`, personal/semantic/episodic/working
+memory, candidates, or existing skill directories. `agentic-stack
+sync-manifest` is available as a repair command if `_manifest.jsonl` drifts
+from installed `SKILL.md` files.
 
 ## Onboarding wizard
 
@@ -375,6 +388,8 @@ harness_manager/                # v0.9.0 manifest-driven Python backend
 ├── transfer_tui.py             # onboarding-style memory transfer wizard
 ├── transfer_plan.py            # natural-language target/scope planning
 ├── transfer_bundle.py          # export/import bundle codec + merge logic
+├── skill_manifest.py           # rebuilds skills/_manifest.jsonl from SKILL.md
+├── upgrade.py                  # safe .agent infrastructure refresh
 └── cli.py                      # argparse dispatcher for install.sh / install.ps1
 
 docs/                           # architecture, getting-started, per-harness

--- a/harness_manager/__init__.py
+++ b/harness_manager/__init__.py
@@ -2,7 +2,7 @@
 
 This package is the implementation backend for `./install.sh` and `./install.ps1`.
 The user-facing surface is plain verbs: install, add, remove, doctor, status,
-dashboard, manage, and transfer.
+dashboard, manage, transfer, upgrade, and sync-manifest.
 The "harness_manager" name is internal only and never appears in CLI help, docs,
 or error messages users see.
 """

--- a/harness_manager/cli.py
+++ b/harness_manager/cli.py
@@ -14,12 +14,25 @@ from . import doctor as doctor_mod
 from . import install as install_mod
 from . import remove as remove_mod
 from . import schema as schema_mod
+from . import skill_manifest as skill_manifest_mod
 from . import state as state_mod
 from . import status as status_mod
+from . import upgrade as upgrade_mod
 from . import __version__
 
 
-VERBS = {"add", "remove", "doctor", "status", "manage", "dashboard", "dash", "transfer"}
+VERBS = {
+    "add",
+    "remove",
+    "doctor",
+    "status",
+    "manage",
+    "dashboard",
+    "dash",
+    "transfer",
+    "upgrade",
+    "sync-manifest",
+}
 
 
 def _stack_root() -> Path:
@@ -263,6 +276,37 @@ def cmd_transfer(args: list[str], target: Path) -> int:
     return transfer_tui.run(args, target_root=target, stack_root=_stack_root())
 
 
+def cmd_sync_manifest(target: Path) -> int:
+    try:
+        skill_manifest_mod.sync_manifest(target)
+        return 0
+    except FileNotFoundError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+
+
+def cmd_upgrade(args: list[str], yes: bool) -> int:
+    dry_run = False
+    target_args: list[str] = []
+    for arg in args:
+        if arg == "--dry-run":
+            dry_run = True
+        elif arg in ("--yes", "-y"):
+            yes = True
+        else:
+            target_args.append(arg)
+    if len(target_args) > 1:
+        print("usage: ./install.sh upgrade [target-dir] [--dry-run] [--yes]", file=sys.stderr)
+        return 2
+    target = Path(target_args[0]) if target_args else Path.cwd()
+    return upgrade_mod.upgrade(
+        target_root=target,
+        stack_root=_stack_root(),
+        dry_run=dry_run,
+        yes=yes,
+    )
+
+
 def cmd_bare(target: Path, wizard_flags: list[str]) -> int:
     """`./install.sh` with no args.
 
@@ -342,6 +386,8 @@ def cmd_bare(target: Path, wizard_flags: list[str]) -> int:
     print("  ./install.sh dashboard   # interactive project dashboard")
     print("  ./install.sh manage      # interactive TUI for adapter management")
     print("  ./install.sh transfer    # onboarding-style memory transfer wizard")
+    print("  ./install.sh upgrade     # safely refresh .agent infrastructure")
+    print("  ./install.sh sync-manifest  # repair skills/_manifest.jsonl")
     return 2
 
 
@@ -487,6 +533,11 @@ def main(argv: list[str] | None = None) -> int:
             return cmd_dashboard(target, plain=plain)
         if verb == "transfer":
             return cmd_transfer(rest[1:], Path.cwd())
+        if verb == "upgrade":
+            return cmd_upgrade(rest[1:], yes=yes)
+        if verb == "sync-manifest":
+            target = Path(rest[1]) if len(rest) >= 2 else Path.cwd()
+            return cmd_sync_manifest(target)
 
     # Treat as adapter name (existing UX)
     adapter = first

--- a/harness_manager/doctor.py
+++ b/harness_manager/doctor.py
@@ -11,6 +11,8 @@ writes. Codex's UX framing: doctor must not mutate without consent.
 from __future__ import annotations
 
 import os
+import json
+import shlex
 import shutil
 import sys
 from pathlib import Path
@@ -234,6 +236,12 @@ def _audit_adapter(
             # Unknown post_install action — just record
             lines.append(f"post_install {action}: {st}")
 
+    if adapter_name == "claude-code":
+        hook_status, hook_lines = _audit_claude_hook_wiring(target_root)
+        if hook_lines:
+            lines.extend(hook_lines)
+            status_overall = max(status_overall, hook_status, key=_status_rank)
+
     # .agent/ brain still intact?
     if not (target_root / ".agent" / "AGENTS.md").is_file():
         lines.append(".agent/AGENTS.md missing — brain not present")
@@ -273,6 +281,91 @@ def _check_openclaw_agent(agent_name: str) -> str:
 
 def _status_rank(s: str) -> int:
     return {GREEN: 0, YELLOW: 1, RED: 2}[s]
+
+
+def _audit_claude_hook_wiring(target_root: Path) -> tuple[str, list[str]]:
+    settings = target_root / ".claude" / "settings.json"
+    if not settings.is_file():
+        return GREEN, []
+    try:
+        data = json.loads(settings.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        return YELLOW, [f".claude/settings.json unreadable JSON: {e}"]
+
+    referenced = _claude_hook_references(data)
+    lines: list[str] = []
+    missing = [
+        rel
+        for rel in sorted(referenced)
+        if rel.startswith(".agent/") and not (target_root / rel).is_file()
+    ]
+    if missing:
+        lines.append(f"missing hook command file(s): {', '.join(missing)}")
+
+    hooks_dir = target_root / ".agent" / "harness" / "hooks"
+    if hooks_dir.is_dir():
+        wired = {rel for rel in referenced if rel.startswith(".agent/harness/hooks/")}
+        orphaned = []
+        for path in sorted(hooks_dir.glob("*.py")):
+            if _ignore_claude_orphan_candidate(path.name):
+                continue
+            rel = path.relative_to(target_root).as_posix()
+            if rel not in wired:
+                orphaned.append(rel)
+        if orphaned:
+            lines.append(
+                "orphaned hook files not referenced by .claude/settings.json: "
+                + ", ".join(orphaned)
+            )
+    return (YELLOW if lines else GREEN), lines
+
+
+def _claude_hook_references(settings: dict) -> set[str]:
+    refs: set[str] = set()
+    hooks = settings.get("hooks") or {}
+    if not isinstance(hooks, dict):
+        return refs
+    for entries in hooks.values():
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            for hook in entry.get("hooks") or []:
+                if not isinstance(hook, dict):
+                    continue
+                command = hook.get("command")
+                if isinstance(command, str):
+                    refs.update(_agent_paths_from_command(command))
+    return refs
+
+
+def _agent_paths_from_command(command: str) -> set[str]:
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        tokens = command.split()
+    refs: set[str] = set()
+    for token in tokens:
+        if ".agent/" not in token:
+            continue
+        rel = token[token.index(".agent/"):].strip(";,")
+        if rel.endswith(".py"):
+            refs.add(rel)
+    return refs
+
+
+def _ignore_claude_orphan_candidate(filename: str) -> bool:
+    if filename == "__init__.py" or filename.startswith("_"):
+        return True
+    if filename in {
+        "on_failure.py",
+        "post_execution.py",
+        "pre_tool_call.py",
+        "pi_post_tool.py",
+    }:
+        return True
+    return False
 
 
 def _summary(doc: dict, any_red: bool) -> str:

--- a/harness_manager/install.py
+++ b/harness_manager/install.py
@@ -13,6 +13,7 @@ from typing import Callable, Iterable
 
 from . import post_install as post_install_mod
 from . import schema as schema_mod
+from . import skill_manifest as skill_manifest_mod
 from . import state as state_mod
 from . import __version__
 
@@ -189,6 +190,8 @@ def install(
     if not target_agent.exists():
         shutil.copytree(stack_root / ".agent", target_agent)
         log("  + .agent/ (portable brain)")
+    if (target_agent / "skills").is_dir():
+        skill_manifest_mod.sync_manifest(target_root, log=lambda _msg: None)
 
     files_written: list[str] = []        # we created — safe for remove to delete
     files_overwritten: list[str] = []    # we modified but file pre-existed — DO NOT delete on remove

--- a/harness_manager/skill_manifest.py
+++ b/harness_manager/skill_manifest.py
@@ -1,0 +1,115 @@
+"""Sync .agent/skills/_manifest.jsonl from SKILL.md frontmatter."""
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Callable
+
+
+LIST_FIELDS = {"triggers", "tools", "preconditions", "constraints"}
+ORDER = ["name", "version", "triggers", "tools", "preconditions", "constraints", "category"]
+
+
+def sync_manifest(target_root: Path | str, log: Callable[[str], None] | None = None) -> int:
+    """Upsert every skills/*/SKILL.md frontmatter block into _manifest.jsonl."""
+    if log is None:
+        log = print
+    target_root = Path(target_root)
+    skills_dir = target_root / ".agent" / "skills"
+    if not skills_dir.is_dir():
+        raise FileNotFoundError(f"skills directory not found: {skills_dir}")
+
+    manifest_path = skills_dir / "_manifest.jsonl"
+    existing_rows = _load_existing(manifest_path)
+    by_name = {row.get("name"): row for row in existing_rows if row.get("name")}
+    seen = set()
+
+    for skill_md in sorted(skills_dir.glob("*/SKILL.md")):
+        parsed = parse_skill_frontmatter(skill_md)
+        name = parsed.get("name")
+        if not name:
+            continue
+        seen.add(name)
+        merged = dict(by_name.get(name) or {})
+        merged.update(parsed)
+        by_name[name] = _ordered(merged)
+
+    ordered_names = []
+    for row in existing_rows:
+        name = row.get("name")
+        if name and name in by_name and name not in ordered_names:
+            ordered_names.append(name)
+    for name in sorted(seen):
+        if name not in ordered_names:
+            ordered_names.append(name)
+
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    with manifest_path.open("w", encoding="utf-8") as f:
+        for name in ordered_names:
+            f.write(json.dumps(by_name[name], separators=(",", ":")) + "\n")
+    log(f"synced {len(seen)} skill manifest entr{'y' if len(seen) == 1 else 'ies'}")
+    return len(seen)
+
+
+def parse_skill_frontmatter(skill_md: Path | str) -> dict:
+    lines = Path(skill_md).read_text(encoding="utf-8").splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}
+    fields: dict = {}
+    for line in lines[1:]:
+        if line.strip() == "---":
+            break
+        if ":" not in line:
+            continue
+        key, raw = line.split(":", 1)
+        key = key.strip()
+        raw = raw.strip()
+        if not key:
+            continue
+        fields[key] = _parse_value(raw, key)
+    return fields
+
+
+def _load_existing(manifest_path: Path) -> list[dict]:
+    if not manifest_path.is_file():
+        return []
+    rows = []
+    for line in manifest_path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(row, dict):
+            rows.append(row)
+    return rows
+
+
+def _parse_value(raw: str, key: str):
+    if key in LIST_FIELDS:
+        return _parse_list(raw)
+    return _strip_quotes(raw)
+
+
+def _parse_list(raw: str) -> list[str]:
+    raw = raw.strip()
+    if raw in ("", "[]"):
+        return []
+    if raw.startswith("[") and raw.endswith("]"):
+        raw = raw[1:-1]
+    return [_strip_quotes(item.strip()) for item in next(csv.reader([raw], skipinitialspace=True)) if item.strip()]
+
+
+def _strip_quotes(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+        return value[1:-1]
+    return value
+
+
+def _ordered(row: dict) -> dict:
+    out = {key: row[key] for key in ORDER if key in row}
+    for key in sorted(k for k in row if k not in out):
+        out[key] = row[key]
+    return out

--- a/harness_manager/upgrade.py
+++ b/harness_manager/upgrade.py
@@ -1,0 +1,112 @@
+"""Project-local .agent infrastructure upgrade."""
+from __future__ import annotations
+
+import fnmatch
+import shutil
+import sys
+from pathlib import Path
+from typing import Callable
+
+from . import skill_manifest
+
+
+def upgrade(
+    target_root: Path | str,
+    stack_root: Path | str,
+    *,
+    dry_run: bool = False,
+    yes: bool = False,
+    log: Callable[[str], None] | None = None,
+) -> int:
+    """Copy safe skeleton-owned .agent files into an installed project."""
+    if log is None:
+        log = print
+    target_root = Path(target_root)
+    stack_root = Path(stack_root)
+    src_agent = stack_root / ".agent"
+    dst_agent = target_root / ".agent"
+    if not dst_agent.is_dir():
+        print(f"error: {dst_agent} not found; install agentic-stack first", file=sys.stderr)
+        return 2
+
+    actions = _plan(src_agent, dst_agent)
+    if not actions:
+        log(f"{target_root}: .agent infrastructure already current")
+    else:
+        log(f"{'would update' if dry_run else 'updating'} {len(actions)} .agent file(s):")
+        for src, dst in actions:
+            log(f"  {'~' if dst.exists() else '+'} {dst.relative_to(target_root)}")
+
+    if dry_run:
+        log("dry run; no files changed")
+        return 0
+
+    if not yes and sys.stdin.isatty():
+        answer = input("apply upgrade? [y/N]: ").strip().lower()
+        if answer not in ("y", "yes"):
+            log("aborted; no files changed")
+            return 0
+    if not yes and not sys.stdin.isatty():
+        print("error: upgrade needs confirmation; re-run with --yes or --dry-run", file=sys.stderr)
+        return 2
+
+    for src, dst in actions:
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dst)
+
+    skill_manifest.sync_manifest(target_root, log=log)
+    return 0
+
+
+def _plan(src_agent: Path, dst_agent: Path) -> list[tuple[Path, Path]]:
+    actions: list[tuple[Path, Path]] = []
+    for rel in _infrastructure_files(src_agent):
+        src = src_agent / rel
+        dst = dst_agent / rel
+        if _needs_copy(src, dst):
+            actions.append((src, dst))
+
+    src_index = src_agent / "skills" / "_index.md"
+    dst_index = dst_agent / "skills" / "_index.md"
+    if src_index.is_file() and _needs_copy(src_index, dst_index):
+        actions.append((src_index, dst_index))
+
+    src_skills = src_agent / "skills"
+    dst_skills = dst_agent / "skills"
+    for skill_md in sorted(src_skills.glob("*/SKILL.md")):
+        skill_dir = skill_md.parent
+        if (dst_skills / skill_dir.name).exists():
+            continue
+        for src in sorted(p for p in skill_dir.rglob("*") if p.is_file() and not _ignored(p)):
+            rel = src.relative_to(src_agent)
+            actions.append((src, dst_agent / rel))
+    return actions
+
+
+def _infrastructure_files(src_agent: Path) -> list[Path]:
+    rels: list[Path] = []
+    for base in ("harness",):
+        root = src_agent / base
+        if root.is_dir():
+            rels.extend(p.relative_to(src_agent) for p in root.rglob("*.py") if not _ignored(p))
+    for base in ("memory", "tools"):
+        root = src_agent / base
+        if root.is_dir():
+            rels.extend(p.relative_to(src_agent) for p in root.glob("*.py") if not _ignored(p))
+    return sorted(rels)
+
+
+def _ignored(path: Path) -> bool:
+    parts = set(path.parts)
+    if "__pycache__" in parts:
+        return True
+    return any(fnmatch.fnmatch(path.name, pattern) for pattern in ("*.pyc", "*.pyo"))
+
+
+def _needs_copy(src: Path, dst: Path) -> bool:
+    if not dst.is_file():
+        return True
+    try:
+        return src.read_bytes() != dst.read_bytes()
+    except OSError:
+        return True

--- a/install.ps1
+++ b/install.ps1
@@ -13,6 +13,8 @@
 #   .\install.ps1 dashboard [target-dir]       # interactive project dashboard
 #   .\install.ps1 manage [target-dir]          # interactive adapter TUI
 #   .\install.ps1 transfer                     # memory transfer wizard
+#   .\install.ps1 upgrade [target-dir] [-Yes]  # safely refresh .agent infra
+#   .\install.ps1 sync-manifest [target-dir]   # repair skills manifest
 #   .\install.ps1                              # bare: install wizard for fresh
 #                                              # projects, dashboard for already
 #                                              # installed interactive projects

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,9 @@
 #   ./install.sh dashboard [target-dir]          # interactive project dashboard
 #   ./install.sh manage [target-dir]             # interactive adapter TUI
 #   ./install.sh transfer                        # memory transfer wizard
+#   ./install.sh upgrade [target-dir] [--dry-run|--yes]
+#                                                # safely refresh .agent infra
+#   ./install.sh sync-manifest [target-dir]       # repair skills manifest
 #   ./install.sh                                 # bare: install wizard for fresh
 #                                                # projects, dashboard for already
 #                                                # installed interactive projects

--- a/test_upgrade_manifest_doctor.py
+++ b/test_upgrade_manifest_doctor.py
@@ -1,0 +1,176 @@
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+
+
+class UpgradeManifestDoctorTest(unittest.TestCase):
+    def run_cli(self, cwd: Path, *args: str):
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(ROOT)
+        env["AGENTIC_STACK_ROOT"] = str(ROOT)
+        return subprocess.run(
+            ["python3", "-m", "harness_manager.cli", *args],
+            cwd=cwd,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def make_brain(self, root: Path) -> Path:
+        agent = root / ".agent"
+        (agent / "harness" / "hooks").mkdir(parents=True)
+        (agent / "memory" / "personal").mkdir(parents=True)
+        (agent / "memory" / "candidates").mkdir(parents=True)
+        (agent / "memory" / "semantic").mkdir(parents=True)
+        (agent / "memory" / "episodic").mkdir(parents=True)
+        (agent / "memory" / "working").mkdir(parents=True)
+        (agent / "protocols").mkdir(parents=True)
+        (agent / "skills").mkdir(parents=True)
+        (agent / "tools").mkdir(parents=True)
+        (agent / "AGENTS.md").write_text("# Brain\n", encoding="utf-8")
+        return agent
+
+    def manifest_rows(self, project: Path) -> list[dict]:
+        manifest = project / ".agent" / "skills" / "_manifest.jsonl"
+        return [
+            json.loads(line)
+            for line in manifest.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+
+    def test_sync_manifest_upserts_skill_frontmatter_and_preserves_extras(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            agent = self.make_brain(project)
+            skill_dir = agent / "skills" / "diagram"
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text(
+                """---
+name: diagram
+version: 2026-05-09
+triggers: ["diagram", "flowchart"]
+tools: [bash, mcp.diagram.draw]
+preconditions: [".agent exists"]
+constraints: ["keep it readable"]
+category: visualization
+---
+
+# Diagram
+""",
+                encoding="utf-8",
+            )
+            (agent / "skills" / "_manifest.jsonl").write_text(
+                json.dumps({"name": "other", "triggers": ["keep"]}) + "\n"
+                + json.dumps({"name": "diagram", "version": "old", "feature_flag": "diagram"}) + "\n",
+                encoding="utf-8",
+            )
+
+            result = self.run_cli(project, "sync-manifest", project)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            rows = {row["name"]: row for row in self.manifest_rows(project)}
+            self.assertEqual(rows["diagram"]["version"], "2026-05-09")
+            self.assertEqual(rows["diagram"]["triggers"], ["diagram", "flowchart"])
+            self.assertEqual(rows["diagram"]["tools"], ["bash", "mcp.diagram.draw"])
+            self.assertEqual(rows["diagram"]["category"], "visualization")
+            self.assertEqual(rows["diagram"]["feature_flag"], "diagram")
+            self.assertEqual(rows["other"]["triggers"], ["keep"])
+
+    def test_upgrade_copies_infrastructure_and_new_skills_without_touching_user_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            agent = self.make_brain(project)
+            (project / "CLAUDE.md").write_text("user claude\n", encoding="utf-8")
+            (project / ".claude").mkdir()
+            (project / ".claude" / "settings.json").write_text('{"user": true}\n', encoding="utf-8")
+            (agent / "harness" / "hooks" / "claude_code_post_tool.py").write_text("old hook\n", encoding="utf-8")
+            (agent / "memory" / "auto_dream.py").write_text("old dream\n", encoding="utf-8")
+            (agent / "tools" / "skill_loader.py").write_text("old loader\n", encoding="utf-8")
+            (agent / "memory" / "personal" / "PREFERENCES.md").write_text("user prefs\n", encoding="utf-8")
+            (agent / "memory" / "candidates" / "candidate.json").write_text("user candidate\n", encoding="utf-8")
+            custom_skill = agent / "skills" / "debug-investigator"
+            custom_skill.mkdir()
+            (custom_skill / "SKILL.md").write_text("user debug skill\n", encoding="utf-8")
+            (agent / "skills" / "_manifest.jsonl").write_text("", encoding="utf-8")
+            (agent / "skills" / "_index.md").write_text("# old index\n", encoding="utf-8")
+
+            result = self.run_cli(project, "upgrade", project, "--yes")
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual((project / "CLAUDE.md").read_text(encoding="utf-8"), "user claude\n")
+            self.assertEqual((project / ".claude" / "settings.json").read_text(encoding="utf-8"), '{"user": true}\n')
+            self.assertEqual((agent / "memory" / "personal" / "PREFERENCES.md").read_text(encoding="utf-8"), "user prefs\n")
+            self.assertEqual((agent / "memory" / "candidates" / "candidate.json").read_text(encoding="utf-8"), "user candidate\n")
+            self.assertEqual((custom_skill / "SKILL.md").read_text(encoding="utf-8"), "user debug skill\n")
+            self.assertEqual(
+                (agent / "harness" / "hooks" / "claude_code_post_tool.py").read_text(encoding="utf-8"),
+                (ROOT / ".agent" / "harness" / "hooks" / "claude_code_post_tool.py").read_text(encoding="utf-8"),
+            )
+            self.assertEqual(
+                (agent / "memory" / "auto_dream.py").read_text(encoding="utf-8"),
+                (ROOT / ".agent" / "memory" / "auto_dream.py").read_text(encoding="utf-8"),
+            )
+            self.assertEqual(
+                (agent / "tools" / "skill_loader.py").read_text(encoding="utf-8"),
+                (ROOT / ".agent" / "tools" / "skill_loader.py").read_text(encoding="utf-8"),
+            )
+            self.assertTrue((agent / "skills" / "tldraw" / "SKILL.md").is_file())
+            rows = {row["name"]: row for row in self.manifest_rows(project)}
+            self.assertIn("tldraw", rows)
+            self.assertIn("draw", rows["tldraw"]["triggers"])
+            self.assertIn("tldraw", (agent / "skills" / "_index.md").read_text(encoding="utf-8"))
+
+    def test_doctor_warns_for_missing_and_unwired_claude_hook_files(self):
+        from harness_manager import doctor
+
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            agent = self.make_brain(project)
+            (project / "CLAUDE.md").write_text("use .agent\n", encoding="utf-8")
+            (project / ".claude").mkdir()
+            (project / ".claude" / "settings.json").write_text(
+                json.dumps(
+                    {
+                        "hooks": {
+                            "PostToolUse": [
+                                {
+                                    "hooks": [
+                                        {
+                                            "type": "command",
+                                            "command": "python3 \"$CLAUDE_PROJECT_DIR/.agent/harness/hooks/missing.py\"",
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (agent / "harness" / "hooks" / "orphan.py").write_text("# orphan\n", encoding="utf-8")
+            entry = {
+                "files_written": ["CLAUDE.md", ".claude/settings.json"],
+                "files_overwritten": [],
+                "file_results": [],
+                "post_install_results": [],
+            }
+
+            status, lines = doctor._audit_adapter(project, "claude-code", entry)
+
+            self.assertEqual(status, doctor.YELLOW)
+            detail = "\n".join(lines)
+            self.assertIn("missing hook command file", detail)
+            self.assertIn(".agent/harness/hooks/missing.py", detail)
+            self.assertIn("orphaned hook files", detail)
+            self.assertIn(".agent/harness/hooks/orphan.py", detail)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `agentic-stack upgrade` with `--dry-run` / `--yes` to refresh skeleton-owned `.agent` infrastructure while leaving adapter configs, user memory, candidates, and existing skill dirs alone
- add `agentic-stack sync-manifest` and run manifest sync during install/add when `.agent/skills` exists
- make `doctor` warn for missing Claude hook command targets and unwired hook files

Fixes #45
Fixes #46
Fixes #47

## Test Plan
- `python3 -m pytest -q`
- `python3 -m py_compile harness_manager/cli.py harness_manager/install.py harness_manager/doctor.py harness_manager/skill_manifest.py harness_manager/upgrade.py`
- `bash -n install.sh`
- `ruby -c Formula/agentic-stack.rb`
- CLI smoke: install fresh project, `sync-manifest`, `upgrade --dry-run`, `upgrade --yes`
- `python3 test_tldraw_visual_memory.py`
- `python3 test_claude_code_hook.py`