### PR TITLE
Add Autohand Code CLI adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Keep one portable memory-and-skills layer across coding-agent harnesses, so switching tools doesn't reset how your agent works.**
 
-A portable `.agent/` folder (memory + skills + protocols) that plugs into Claude Code, Cursor, Windsurf, OpenCode, OpenClaw, GitHub Copilot CLI, Google Gemini CLI, Hermes, Pi Coding Agent, Codex, Antigravity, or a DIY Python loop — and keeps its knowledge when you switch.
+A portable `.agent/` folder (memory + skills + protocols) that plugs into Claude Code, Cursor, Windsurf, OpenCode, OpenClaw, GitHub Copilot CLI, Google Gemini CLI, Hermes, Pi Coding Agent, Codex, Autohand Code CLI, Antigravity, or a DIY Python loop — and keeps its knowledge when you switch.
 
 It also includes a local data layer so you can monitor the whole suite of
 agents from one place: harness activity, cron runs, active agents, token/cost
@@ -142,7 +142,7 @@ brew install agentic-stack
 # drop the brain into any project — the onboarding wizard runs automatically
 cd your-project
 agentic-stack claude-code
-# or: cursor | windsurf | opencode | openclaw | copilot-cli | gemini | hermes | pi | codex | standalone-python | antigravity
+# or: cursor | windsurf | opencode | openclaw | copilot-cli | gemini | hermes | pi | codex | autohand-code | standalone-python | antigravity
 ```
 
 ### Windows (PowerShell)
@@ -167,7 +167,7 @@ agentic-stack dashboard
 git clone https://github.com/codejunkie99/agentic-stack.git
 cd agentic-stack && ./install.sh claude-code         # mac / linux / git-bash
 # or on Windows PowerShell: .\install.ps1 claude-code
-# adapters: claude-code | cursor | windsurf | opencode | openclaw | copilot-cli | gemini | hermes | pi | codex | standalone-python | antigravity
+# adapters: claude-code | cursor | windsurf | opencode | openclaw | copilot-cli | gemini | hermes | pi | codex | autohand-code | standalone-python | antigravity
 ```
 
 ### Once installed: manage what's wired
@@ -244,7 +244,7 @@ from installed `SKILL.md` files.
 ## Onboarding wizard
 
 If you ran bare `./install.sh` (no adapter name), the wizard starts
-with a **multi-select harness step**: it lists all 12 adapters, pre-
+with a **multi-select harness step**: it lists all 13 adapters, pre-
 checks any it detects on disk, and installs each one you confirm with
 space + enter. After the install(s), the preferences flow runs.
 
@@ -437,6 +437,7 @@ adapters/                       # one small shim per harness, each with adapter.
 ├── hermes/        (AGENTS.md)
 ├── pi/            (AGENTS.md + .pi/skills symlink)
 ├── codex/         (AGENTS.md + .agents/skills symlink)
+├── autohand-code/ (AGENTS.md + .autohand/skills symlink)
 ├── standalone-python/  (DIY conductor entrypoint)
 └── antigravity/   (ANTIGRAVITY.md)
 
@@ -495,6 +496,7 @@ verify_codex_fixes.py           # v0.8.0 regression checks (33 checks)
 | **Hermes Agent** | `AGENTS.md` (agentskills.io compatible) | partial (own memory) |
 | **Pi Coding Agent** | `AGENTS.md` + `.pi/skills/` + `.pi/extensions/` | yes (`tool_result` event) |
 | **Codex** | `AGENTS.md` + `.agents/skills/` | no (manual reflect calls) |
+| **Autohand Code CLI** | `AGENTS.md` + `.autohand/skills/` | no (manual reflect calls) |
 | **Standalone Python** | `run.py` (any LLM) | yes (full control) |
 | **Antigravity** | `ANTIGRAVITY.md` | yes (system context) |
 

--- a/adapters/autohand-code/AGENTS.md
+++ b/adapters/autohand-code/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENTS.md — Autohand Code CLI adapter for agentic-stack
+
+Autohand Code CLI reads `AGENTS.md` as project instructions. This file
+points it at the portable `.agent/` brain so Autohand shares the same
+memory, skills, and protocols as the other installed harnesses.
+
+Before acting:
+
+1. Read `.agent/AGENTS.md`.
+2. Read `.agent/memory/personal/PREFERENCES.md` when it exists.
+3. Use `.agent/tools/recall.py "<task intent>"` for relevant accepted
+   lessons on non-trivial work.
+4. Prefer skills from `.agent/skills/` when their triggers match.
+
+After meaningful work, record a short reflection through
+`.agent/tools/memory_reflect.py` so the normal dream/review cycle can
+stage candidate lessons.

--- a/adapters/autohand-code/README.md
+++ b/adapters/autohand-code/README.md
@@ -1,0 +1,48 @@
+# Autohand Code CLI adapter
+
+[Autohand Code CLI](https://github.com/autohandai/code-cli) reads
+`AGENTS.md` for project instructions and discovers project skills from
+`.autohand/skills/`. This adapter layers the portable `.agent/` brain on
+top so Autohand can share the same memory, skills, and protocols as the
+other harnesses.
+
+## Install
+```bash
+./install.sh autohand-code
+```
+
+Or on Windows PowerShell:
+```powershell
+.\install.ps1 autohand-code C:\path\to\your-project
+```
+
+## What it wires up
+- `AGENTS.md` — Autohand reads this as project instructions. If another
+  adapter already installed `AGENTS.md`, this adapter leaves it in place.
+- `.autohand/skills/` → `.agent/skills/` — Autohand scans this path for
+  project-level skills. The installer creates a symlink when possible
+  and falls back to copying / merging when symlinks are unavailable.
+
+## Verify
+Run Autohand in the project and ask:
+
+```bash
+autohand "Summarize the current instructions."
+```
+
+It should mention `.agent/AGENTS.md` and the portable memory files.
+
+Then ask:
+
+```bash
+autohand "What's in my lessons file?"
+```
+
+It should read `.agent/memory/semantic/LESSONS.md`.
+
+## Notes
+- This adapter does not install Autohand hooks. It relies on the same
+  manual `recall.py` and `memory_reflect.py` calls used by the Cursor
+  and Windsurf paths.
+- If `.autohand/skills/` is a copied directory rather than a symlink,
+  re-run the installer after editing `.agent/skills/` to sync updates.

--- a/adapters/autohand-code/adapter.json
+++ b/adapters/autohand-code/adapter.json
@@ -1,0 +1,16 @@
+{
+  "name": "autohand-code",
+  "description": "Autohand Code CLI — AGENTS.md + .autohand/skills mirror (Autohand project-level skills directory per https://github.com/autohandai/code-cli).",
+  "files": [
+    {
+      "src": "AGENTS.md",
+      "dst": "AGENTS.md",
+      "merge_policy": "skip_if_exists"
+    }
+  ],
+  "skills_link": {
+    "target": ".agent/skills",
+    "dst": ".autohand/skills",
+    "fallback": "rsync_with_delete"
+  }
+}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,7 +40,7 @@ If you installed with Homebrew, run the CLI from your project root:
 ```bash
 cd your-project
 agentic-stack claude-code
-# or: cursor | windsurf | opencode | openclaw | copilot-cli | gemini | hermes | pi | codex | standalone-python | antigravity
+# or: cursor | windsurf | opencode | openclaw | copilot-cli | gemini | hermes | pi | codex | autohand-code | standalone-python | antigravity
 ```
 
 If you are using a source checkout, the install command above already picked

--- a/docs/per-harness/autohand-code.md
+++ b/docs/per-harness/autohand-code.md
@@ -1,0 +1,53 @@
+# Autohand Code CLI setup
+
+[Autohand Code CLI](https://github.com/autohandai/code-cli) reads
+`AGENTS.md` as project instructions and discovers project skills from
+`.autohand/skills/`. Our adapter layers the portable `.agent/` brain on
+top so you keep one knowledge base even if you later swap harnesses.
+
+## What the adapter installs
+- `AGENTS.md` at project root. Skipped if one already exists, since
+  Autohand, pi, hermes, opencode, and Codex can share the same file.
+- `.autohand/skills/` symlinked to `.agent/skills/` when possible.
+  Falls back to copying / merging on platforms without symlink support.
+
+## Install
+```bash
+./install.sh autohand-code
+autohand
+```
+
+On Windows PowerShell:
+```powershell
+.\install.ps1 autohand-code C:\path\to\your-project
+autohand
+```
+
+## How it works
+- Autohand loads `AGENTS.md` as repository guidance. The adapter file
+  points it at `.agent/AGENTS.md`, `PREFERENCES.md`, `LESSONS.md`, and
+  `permissions.md`.
+- Autohand scans `.autohand/skills/` for project-level skills. The
+  adapter mirrors `.agent/skills/` there so portable skills are visible
+  without duplication.
+- The adapter intentionally does not install Autohand hooks. Manual
+  `recall.py` and `memory_reflect.py` calls remain the stable
+  cross-platform path.
+
+## Verify
+```bash
+autohand "Summarize the current instructions."
+autohand "What's in my lessons file?"
+```
+
+Expected:
+- the first command mentions `.agent/AGENTS.md`
+- the second reads `.agent/memory/semantic/LESSONS.md`
+
+## Troubleshooting
+- If Autohand does not pick up `AGENTS.md`, restart it from the
+  repository root and run the `Summarize the current instructions` check
+  again.
+- If skills are missing, inspect `.autohand/skills/`. On filesystems
+  without symlink support, the installer copies / merges the directory
+  instead; re-run the installer after updating `.agent/skills/`.

--- a/harness_manager/doctor.py
+++ b/harness_manager/doctor.py
@@ -38,6 +38,7 @@ DETECT_SIGNALS = {
     "openclaw": [(".openclaw-system.md", "strong")],
     "pi": [(".pi/extensions/memory-hook.ts", "strong")],
     "codex": [(".agents/skills", "strong")],
+    "autohand-code": [(".autohand/skills", "strong")],
     "antigravity": [("ANTIGRAVITY.md", "strong")],
     "opencode": [("opencode.json", "strong")],
     "hermes": [("AGENTS.md", "weak")],  # AGENTS.md alone is ambiguous

--- a/harness_manager/transfer_plan.py
+++ b/harness_manager/transfer_plan.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Iterable
 
 
-VALID_TARGETS = ("codex", "cursor", "windsurf", "terminal")
+VALID_TARGETS = ("codex", "autohand-code", "cursor", "windsurf", "terminal")
 CORE_SCOPES = ("preferences", "accepted_lessons", "skills")
 DEFAULT_SCOPES = CORE_SCOPES + ("working", "episodic", "candidates")
 SENSITIVE_SCOPES = ("working", "episodic", "candidates", "data_layer", "flywheel")
@@ -16,6 +16,9 @@ VALID_SCOPES = CORE_SCOPES + SENSITIVE_SCOPES
 TARGET_ALIASES = {
     "codex": "codex",
     "openai": "codex",
+    "autohand": "autohand-code",
+    "autohand-code": "autohand-code",
+    "autohand-code-cli": "autohand-code",
     "cursor": "cursor",
     "windsurf": "windsurf",
     "cascade": "windsurf",

--- a/install.ps1
+++ b/install.ps1
@@ -22,7 +22,7 @@
 #                                              # installed interactive projects
 #
 # adapter-name: claude-code | copilot-cli | cursor | gemini | windsurf |
-#               opencode | openclaw | hermes | pi | codex |
+#               opencode | openclaw | hermes | pi | codex | autohand-code |
 #               standalone-python | antigravity
 #
 # All real logic lives in harness_manager/ (Python). This script is a

--- a/install.sh
+++ b/install.sh
@@ -23,7 +23,7 @@
 #                                                # installed interactive projects
 #
 # adapter-name: claude-code | copilot-cli | cursor | gemini | windsurf |
-#               opencode | openclaw | hermes | pi | codex |
+#               opencode | openclaw | hermes | pi | codex | autohand-code |
 #               standalone-python | antigravity
 #
 # All real logic lives in harness_manager/ (Python). This script is a


### PR DESCRIPTION
## Summary

Adds an Autohand Code CLI adapter to agentic-stack.

The new adapter follows the existing manifest-driven harness pattern:

- installs an `AGENTS.md` entry point for Autohand project instructions
- mirrors `.agent/skills/` into `.autohand/skills/`, which Autohand uses for project-level skills
- adds per-harness docs and README/getting-started references
- includes doctor detection and transfer-target aliases for `autohand` / `autohand-code`

Autohand Code CLI lives at https://github.com/autohandai/code-cli.

## Validation

- `python3 -m unittest tests.test_transfer_plan tests.test_transfer_cli tests.test_upgrade_manifest_doctor`
- validated `adapters/autohand-code/adapter.json` through `harness_manager.schema.validate`
- built a transfer plan for `move my memory into autohand` and confirmed it targets `autohand-code`
- installed into a temp project with `python3 -m harness_manager.cli autohand-code /tmp/agentic-stack-autohand-test --yes` and verified `AGENTS.md`, `.agent/install.json`, and `.autohand/skills` were created


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `autohand-code` CLI adapter with detection, transfer, and documentation
> - Adds a new `autohand-code` adapter that installs [AGENTS.md](https://github.com/codejunkie99/agentic-stack/pull/52/files#diff-fe1c69e33879c13ecb94efb30e6b36b8c40fd8a663de640fb910efa62e56edba) to the project root and symlinks `.agent/skills` to `.autohand/skills` (with `rsync_with_delete` as fallback when symlinks are unavailable).
> - Registers `autohand-code` in [transfer_plan.py](https://github.com/codejunkie99/agentic-stack/pull/52/files#diff-53f29d3ca8b57d563d3ed229e09a375bf506e61d3feaf5cee2aef10dd9587d44) as a valid transfer target, with aliases `autohand` and `autohand-code-cli`.
> - Adds detection in [doctor.py](https://github.com/codejunkie99/agentic-stack/pull/52/files#diff-f76817c0eea8885fcc253517a05850fc5a357bbca2c4549b9360fd7b05e72257) using the presence of `.autohand/skills` as a strong signal.
> - Updates install scripts, README, and getting-started docs to include the new adapter (adapter count: 12 → 13).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 43ae8e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->