### PR TITLE
fix(memory): stage() mirrors manual lessons into AGENT_LEARNINGS.jsonl

### DIFF
--- a/.agent/tools/learn.py
+++ b/.agent/tools/learn.py
@@ -55,6 +55,34 @@ def _lesson_already_appended(cid):
     return False
 
 
+def _append_episodic_mirror(cid, claim, ts, source="learn"):
+    """Mirror a manual stage into AGENT_LEARNINGS.jsonl so evidence_ids
+    referencing `ts` resolve to a real episodic record — matching the
+    auto-derived candidate path's existing behavior. Never raises; a
+    failure here must not block staging (same fail-open posture as
+    _lesson_already_appended's read-only probe).
+    """
+    episodic_path = os.path.join(BASE, "memory/episodic/AGENT_LEARNINGS.jsonl")
+    entry = {
+        "timestamp": ts,
+        "skill": "learn",
+        "action": f"manual-stage:{cid}",
+        "result": "success",
+        "detail": f"Manually staged lesson {cid} via .agent/tools/learn.py: {claim!r}",
+        "pain_score": 1,
+        "importance": 6,
+        "reflection": "",
+        "confidence": 0.9,
+        "source": {"skill": "learn", "profile": "manual", "run_id": f"manual_{cid[:6]}"},
+        "evidence_ids": [ts],
+    }
+    try:
+        with open(episodic_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry) + "\n")
+    except OSError:
+        pass  # fail-open: staging must succeed even if the mirror write fails
+
+
 def stage(claim, conditions, source="learn", importance=7):
     os.makedirs(CANDIDATES, exist_ok=True)
     cid = pattern_id(claim, conditions)
@@ -79,6 +107,7 @@ def stage(claim, conditions, source="learn", importance=7):
     path = os.path.join(CANDIDATES, f"{cid}.json")
     with open(path, "w") as f:
         json.dump(candidate, f, indent=2)
+    _append_episodic_mirror(cid, claim, now, source)
     return cid, path
 
 

--- a/.agent/tools/test_learn_episodic_mirror.py
+++ b/.agent/tools/test_learn_episodic_mirror.py
@@ -1,0 +1,85 @@
+"""Regression test for learn.py's manual-stage episodic mirror.
+
+Standalone (stdlib `unittest`, no third-party test dependency) because this
+project currently ships no test harness — this is intended as the first test
+file, easy to run with `python3 -m unittest` from the repo root or to remove
+if the maintainer prefers to merge the fix without it.
+
+Adapted from the downstream Perpetua-Tools suite that proved this fix
+(3 passing tests + 6 real-world learn.py invocations, all evidence_ids
+verified to resolve).
+"""
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+
+def _load_learn(base_dir):
+    """Load .agent/tools/learn.py with BASE/CANDIDATES pointed at base_dir.
+
+    Sibling modules (text.word_set, cluster.pattern_id) are stubbed so the
+    test needs no part of the harness beyond learn.py itself.
+    """
+    for name, attrs in [
+        ("text", {"word_set": lambda *a, **k: set()}),
+        ("cluster", {"pattern_id": lambda claim, cond: "testcid" + str(abs(hash((claim, tuple(cond)))))[:6]}),
+    ]:
+        m = types.ModuleType(name)
+        for k, v in attrs.items():
+            setattr(m, k, v)
+        sys.modules[name] = m
+
+    module_path = Path(__file__).with_name("learn.py")
+    spec = importlib.util.spec_from_file_location("learn_under_test", module_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    mod.BASE = base_dir
+    mod.CANDIDATES = os.path.join(base_dir, "memory", "candidates")
+    os.makedirs(mod.CANDIDATES, exist_ok=True)
+    os.makedirs(os.path.join(base_dir, "memory", "episodic"), exist_ok=True)
+    return mod
+
+
+def _episodic(base_dir):
+    path = os.path.join(base_dir, "memory", "episodic", "AGENT_LEARNINGS.jsonl")
+    if not os.path.exists(path):
+        return []
+    with open(path, encoding="utf-8") as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+class EpisodicMirrorTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def test_stage_writes_one_episodic_mirror(self):
+        mod = _load_learn(self.tmp)
+        cid, _ = mod.stage("Serialize timestamps in UTC", ["timestamps", "utc"])
+        entries = _episodic(self.tmp)
+        mirrors = [e for e in entries if e.get("action") == f"manual-stage:{cid}"]
+        self.assertEqual(len(mirrors), 1)
+
+    def test_evidence_id_resolves_to_the_mirror(self):
+        mod = _load_learn(self.tmp)
+        cid, path = mod.stage("Serialize timestamps in UTC", ["timestamps", "utc"])
+        candidate = json.loads(Path(path).read_text())
+        evidence_ts = candidate["evidence_ids"][0]
+        matching = [e for e in _episodic(self.tmp) if e["timestamp"] == evidence_ts]
+        self.assertEqual(len(matching), 1)
+        self.assertEqual(matching[0]["evidence_ids"], [evidence_ts])
+
+    def test_append_mirror_fails_open_on_write_error(self):
+        mod = _load_learn(self.tmp)
+        mod.BASE = os.path.join(self.tmp, "does-not-exist")
+        # Must not raise even though the target directory is missing.
+        mod._append_episodic_mirror("deadbeef", "claim", "2026-01-01T00:00:00+00:00")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Atomic PR **01** of _3_

## Summary

`stage()`'s manual-lesson path writes a candidate with `evidence_ids: [now]`, promising an episodic record exists at that timestamp in `AGENT_LEARNINGS.jsonl` — but never writes one. The auto-derived candidate path mirrors correctly; the manual path doesn't. Result: a graduated lesson's `evidence_ids` can point at a timestamp with no matching episodic record.

## Fix

Adds `_append_episodic_mirror()`, called right after the candidate file is written, using the same timestamp so `evidence_ids[0]` always resolves.

Fail-open on `OSError` — a mirror-write failure never blocks staging.
Minimal, additive, stdlib-only.

## Verification

- Applied cleanly to `master` @ `00eda65c`, syntax-checked.
- Isolated functional test: `stage()` now writes exactly one episodic mirror whose timestamp equals the candidate's `evidence_ids[0]`.
- 3 unit tests (see commit 2, kept separate — see below), all passing.
- Found and fixed downstream in [Perpetua-Tools](https://github.com/diazMelgarejo/Perpetua-Tools), which vendors this project (`vendor/agentic-stack`). Validated there in two ways: 3 unit tests, and 6 real, non-test invocations of the fixed `learn.py` — all 6 evidence_ids verified programmatically to resolve to exactly one matching episodic record. Both are on PT `main`, commits `95f047f` (fix) and `61dee0d` (real-world validation), if useful cross-reference.

## Two commits, intentionally separate

1. `fix(memory): ...` — the fix alone.
2. `test(memory): ...` — a standalone `unittest` (no pytest or other third-party dependency, since this project doesn't currently ship a test harness). Kept as a **separate commit specifically so you can cherry-pick it out** if you'd rather merge the fix without introducing the project's first test file this way.

**Question for you:** would you like the test included as-is, dropped, or adapted to a different location/convention? Fully open to whatever fits this project, this is offered as a starting point, not a requirement.

## Background check

Searched open/closed issues and PRs for `episodic`, `evidence_ids`, `mirror`, no duplicate report. (#13 is a related-but-different gap: adapters not auto-populating the episodic log at all; this fix is about the manual-stage path specifically not mirroring.)

## Note on this PR and its siblings

This is PR 1 of 3 prepared together as a small, related set (each stacked on the previous: [#2](https://github.com/diazMelgarejo/agentic-stack/pull/1) will be based on this branch, [#3](https://github.com/diazMelgarejo/agentic-stack/pull/2) on [#2](https://github.com/diazMelgarejo/agentic-stack/pull/1)), separated so each can be reviewed and merged on its own merit, but designed as a set. (My own personal working patch on top of your latest release!)

Opening this one first; happy to hold 2 and 3 until this lands, or just open them now for visibility from my end, and mentioned here for transparency rather than surprising you with a queue later on. They can also all land together, whichever you prefer.

Thank you,

ALL THE BEST!

P.S.: your 0.19 draft spec looks exciting 💪🏼

---

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mirror manual `stage()` calls into `AGENT_LEARNINGS.jsonl` as episodic records
> - Adds `_append_episodic_mirror` in [learn.py](https://github.com/codejunkie99/agentic-stack/pull/57/files#diff-57b1de13d999005efb1852d343e87ff6fb86ce2ac93efc787dca2bc2d364cd14) that writes a JSONL entry to `memory/episodic/AGENT_LEARNINGS.jsonl` whenever a lesson is manually staged, using the same timestamp as the candidate file.
> - The mirror record includes action `manual-stage:{cid}`, pain score, importance, confidence, and evidence IDs linking back to the candidate.
> - Write failures are silently suppressed (fail-open) so staging is never blocked by a mirror write error.
> - Adds unit tests in [test_learn_episodic_mirror.py](https://github.com/codejunkie99/agentic-stack/pull/57/files#diff-57803f761db3789a435b6bcef63649ff00d66747a964cef678a5c90573a5badb) covering one-record output, evidence ID resolution, and fail-open behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a3d5139.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->