### PR TITLE
fix(io): force UTF-8 on stdout/stderr and candidate writes

### DIFF
--- a/.agent/tools/learn.py
+++ b/.agent/tools/learn.py
@@ -20,6 +20,10 @@ orphaned dead-ends.
 """
 import argparse, datetime, json, os, subprocess, sys
 
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
 BASE = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 CANDIDATES = os.path.join(BASE, "memory/candidates")
 sys.path.insert(0, os.path.join(BASE, "harness"))
@@ -105,7 +109,7 @@ def stage(claim, conditions, source="learn", importance=7):
         "rejection_count": 0,
     }
     path = os.path.join(CANDIDATES, f"{cid}.json")
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         json.dump(candidate, f, indent=2)
     _append_episodic_mirror(cid, claim, now, source)
     return cid, path


### PR DESCRIPTION
Atomic PR **2** of 3 (PR 1, episodic-mirror, merged as #57).

## Summary

Two small UTF-8 robustness fixes in `.agent/tools/learn.py`, both stdlib-only:

1. Force UTF-8 on `sys.stdout`/`sys.stderr` at import time (guarded by `hasattr(..., "reconfigure")` for older Python), so non-ASCII claim text prints correctly regardless of the host locale — matters most on Windows, where the default console codepage isn't UTF-8.
2. `open(path, "w")` → `open(path, "w", encoding="utf-8")` for the candidate JSON write, so it doesn't silently pick up the platform default encoding.

Rebased onto current `master` — the branch originally also carried PR #1's commits (stacked, per the original 3-PR plan); those are now dropped since #57 already merged that content, leaving only this PR's own diff.

## Tests

Full suite passes on top of current `master`: 177 passed (+ 3 in `.agent/tools/test_learn_episodic_mirror.py`), 1 pre-existing unrelated failure (`test_unknown_executable_is_a_structured_start_failure`, a macOS `PermissionError`-vs-`FileNotFoundError` platform quirk unrelated to this change).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Force UTF-8 encoding on stdout/stderr and candidate file writes in `learn.py`
> - Reconfigures `sys.stdout` and `sys.stderr` to use UTF-8 with `errors='replace'` at module startup in [learn.py](https://github.com/codejunkie99/agentic-stack/pull/61/files#diff-57b1de13d999005efb1852d343e87ff6fb86ce2ac93efc787dca2bc2d364cd14), replacing unencodable characters instead of raising errors.
> - The `stage()` function now explicitly passes `encoding='utf-8'` when writing candidate JSON files, replacing reliance on the platform default encoding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5e38f01.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->