### PR TITLE
fix(io): use a context manager in _lesson_already_appended

### DIFF
--- a/.agent/tools/learn.py
+++ b/.agent/tools/learn.py
@@ -20,6 +20,10 @@ orphaned dead-ends.
 """
 import argparse, datetime, json, os, subprocess, sys
 
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
 BASE = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 CANDIDATES = os.path.join(BASE, "memory/candidates")
 sys.path.insert(0, os.path.join(BASE, "harness"))
@@ -105,7 +109,7 @@ def stage(claim, conditions, source="learn", importance=7):
         "rejection_count": 0,
     }
     path = os.path.join(CANDIDATES, f"{cid}.json")
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         json.dump(candidate, f, indent=2)
     _append_episodic_mirror(cid, claim, now, source)
     return cid, path

--- a/.agent/tools/learn.py
+++ b/.agent/tools/learn.py
@@ -44,16 +44,17 @@ def _lesson_already_appended(cid):
         return False
     target = f"lesson_{cid}"
     try:
-        for line in open(lessons_path):
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                row = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            if row.get("id") == target:
-                return True
+        with open(lessons_path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if row.get("id") == target:
+                    return True
     except OSError:
         return False
     return False


### PR DESCRIPTION
Atomic PR **3** of 3 (PR 1, episodic-mirror, merged as #57; PR 2, UTF-8 fixes, #61 — this PR is built on top of it, so its diff includes #61's commit until that one merges).

## Summary

`_lesson_already_appended()` opened `lessons_path` with a bare `open()` and never closed it explicitly — relying on GC/refcounting to close the file handle. Same resource-safety class as the file-handle findings from this project's own recent hygiene passes. Wraps the read in a `with open(lessons_path, encoding="utf-8") as f:` block; also picks up explicit UTF-8 encoding, consistent with #61.

## Tests

Same suite as #61 (built on top of it): 177 passed, 1 pre-existing unrelated failure (`test_unknown_executable_is_a_structured_start_failure`).

Please merge #61 first — once it lands, this PR's diff collapses to just this fix's own delta.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix file handling in `_lesson_already_appended` to use a context manager with UTF-8 encoding
> Updates [learn.py](https://github.com/codejunkie99/agentic-stack/pull/62/files#diff-57b1de13d999005efb1852d343e87ff6fb86ce2ac93efc787dca2bc2d364cd14) to consistently use UTF-8 encoding across file reads and writes, preventing locale-dependent encoding errors.
>
> - `_lesson_already_appended` now opens `lessons.jsonl` with a context manager and explicit UTF-8 encoding instead of relying on system defaults.
> - `stage` writes candidate JSON files with explicit UTF-8 encoding to preserve non-ASCII content.
> - `sys.stdout` and `sys.stderr` are reconfigured to UTF-8 with `errors='replace'` at module load time.
> - Behavioral Change: files previously read or written using the system locale encoding will now always use UTF-8; this may surface previously hidden encoding mismatches.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f685a08.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->