### PR TITLE
fix(upgrade): loop-* skill copy doubles the skills/ path segment

### DIFF
--- a/harness_manager/upgrade.py
+++ b/harness_manager/upgrade.py
@@ -108,7 +108,7 @@ def _new_loop_assets(src_agent: Path, dst_agent: Path) -> list[tuple[Path, Path]
         if not skill_dir.is_dir() or (dst_skills / skill_dir.name).exists():
             continue
         for src in sorted(p for p in skill_dir.rglob("*") if p.is_file()):
-            actions.append((src, dst_skills / src.relative_to(src_agent)))
+            actions.append((src, dst_agent / src.relative_to(src_agent)))
     return actions
 
 

--- a/tests/test_loop_integrations.py
+++ b/tests/test_loop_integrations.py
@@ -42,6 +42,21 @@ def test_upgrade_adds_missing_loop_assets_but_preserves_authored_contract(tmp_pa
     assert (target / ".agent" / "runtime" / ".gitignore").exists()
 
 
+def test_upgrade_copies_missing_loop_skills_to_the_correct_path(tmp_path: Path):
+    """A genuinely-missing loop-* skill must land at .agent/skills/loop-x/,
+    not .agent/skills/skills/loop-x/ (a doubled path segment regression:
+    the existing coverage above only ever pre-seeds loop-triage, so it
+    exercises the "already exists, skip" branch and never the fresh-copy
+    branch that builds the destination path).
+    """
+    target = make_installed_project(tmp_path)
+    assert upgrade(target, ROOT, yes=True) == 0
+    for name in ("loop-constraints", "loop-guard", "loop-triage", "loop-verifier"):
+        dst = target / ".agent" / "skills" / name / "SKILL.md"
+        assert dst.is_file(), f"expected {dst}, not doubled under skills/skills/"
+        assert not (target / ".agent" / "skills" / "skills").exists()
+
+
 def test_upgrade_does_not_copy_runtime_children_or_overwrite_loop_skills(tmp_path: Path):
     target = make_installed_project(tmp_path)
     skill = target / ".agent" / "skills" / "loop-triage"


### PR DESCRIPTION
## Summary

`_new_loop_assets()` in `harness_manager/upgrade.py` computes each new `loop-*` skill's destination as `dst_skills / src.relative_to(src_agent)`. `src.relative_to(src_agent)` already starts with `skills/` (`src_agent` is `.agent/`, not `.agent/skills/`), and `dst_skills` is already `.agent/skills/` — so every genuinely-new `loop-*` skill lands at `.agent/skills/skills/loop-x/SKILL.md` instead of `.agent/skills/loop-x/SKILL.md`. Both `upgrade --dry-run`'s own report and the real file copy are wrong.

This went unnoticed because the existing test coverage in `tests/test_loop_integrations.py` only ever pre-seeds `loop-triage` at the destination before calling `upgrade()` — so it exercises the "already exists, skip" branch and never the fresh-copy branch that actually builds the destination path.

## Fix

`dst_agent / src.relative_to(src_agent)`, matching the sibling non-loop skill-copy block earlier in the same function (`_plan()`, ~15 lines above), which already gets this right.

## Tests

New: `test_upgrade_copies_missing_loop_skills_to_the_correct_path` — calls `upgrade()` against a fresh target with none of the `loop-*` skills pre-seeded, and asserts each lands at the correct (non-doubled) path.

Confirmed via `git stash` that this test fails on the old code (asserts the doubled path is absent) and passes on the fix.

```
python3 -m pytest tests/test_loop_integrations.py -v
# 5 passed
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix duplicate `skills/` path segment when copying `loop-*` skill files during upgrade
> In `_new_loop_assets`, the destination path for `loop-*` skill copy actions was built using `dst_skills / src.relative_to(src_agent)`, which produced `.agent/skills/skills/loop-*/...`. The fix uses `dst_agent / src.relative_to(src_agent)` instead, targeting the correct `.agent/skills/loop-*/...` path. A new integration test in [test_loop_integrations.py](https://github.com/codejunkie99/agentic-stack/pull/63/files#diff-8750e0e7631cfe2f725b665b832f8aad94741657235a57e026cadeee5a0bd282) asserts the correct destination and confirms no `.agent/skills/skills` directory is created.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 312f132.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->