### PR TITLE
Add Fable 5.1 parent / Grok 4.6 subagent cavecrew stack for Cursor agents

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -96,11 +96,16 @@ Daily driver, highest-leverage first:
 
 ## Cursor model split (Fable parent, Grok subagents)
 
-When running under Cursor (local or cloud), the root `.cursor/` directory
-installs a model split on top of this brain:
-- Parent agent: Claude Fable 5.1. Judgment, scoping, synthesis only.
+When running under Cursor (local or cloud), the Cursor adapter installs a model
+split on top of this brain. Before starting the session, select Claude Fable
+5.1 for the parent in Cursor's model picker; project rules cannot pin the
+parent model:
+- Parent agent: Claude Fable 5.1 when selected at session start. Judgment,
+  scoping, and synthesis only.
 - Subagents: Grok 4.6, pinned via `model: grok-4.6` in `.cursor/agents/cavecrew-{investigator,builder,reviewer}.md`.
 - Rules: `.cursor/rules/fable-grok-subagents.mdc`, `.cursor/rules/caveman.mdc` (both `alwaysApply`).
-- Skills: `.cursor/skills/caveman/SKILL.md`, `.cursor/skills/cavecrew/SKILL.md` (MIT, from JuliusBrussee/caveman).
+- Skills: `.cursor/skills/caveman/SKILL.md`, `.cursor/skills/cavecrew/SKILL.md`
+  (adapted from JuliusBrussee/caveman under the adjacent MIT license notices).
 Locate, bulk grep, 1-2 file edits, and diff review go to the cavecrew
-subagents. See `protocols/delegation.md` for general sub-agent handoff rules.
+subagents. This is the narrow Cursor exception defined by
+`protocols/delegation.md`; its general handoff rules still apply elsewhere.

--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -93,3 +93,14 @@ Daily driver, highest-leverage first:
 6. Follow `protocols/permissions.md`. Blocked means blocked.
 7. When a self-rewrite hook fires, propose conservative edits only.
 8. The harness is dumb on purpose. Reasoning lives in skills + the host agent.
+
+## Cursor model split (Fable parent, Grok subagents)
+
+When running under Cursor (local or cloud), the root `.cursor/` directory
+installs a model split on top of this brain:
+- Parent agent: Claude Fable 5.1. Judgment, scoping, synthesis only.
+- Subagents: Grok 4.6, pinned via `model: grok-4.6` in `.cursor/agents/cavecrew-{investigator,builder,reviewer}.md`.
+- Rules: `.cursor/rules/fable-grok-subagents.mdc`, `.cursor/rules/caveman.mdc` (both `alwaysApply`).
+- Skills: `.cursor/skills/caveman/SKILL.md`, `.cursor/skills/cavecrew/SKILL.md` (MIT, from JuliusBrussee/caveman).
+Locate, bulk grep, 1-2 file edits, and diff review go to the cavecrew
+subagents. See `protocols/delegation.md` for general sub-agent handoff rules.

--- a/.agent/protocols/delegation.md
+++ b/.agent/protocols/delegation.md
@@ -12,6 +12,14 @@ Rules for when and how to hand work off to a sub-agent.
 - The context needed by the sub-agent overlaps heavily with the parent's.
 - The sub-agent would need to write to memory that the parent is actively editing.
 
+## Harness-specific exceptions
+- An adapter may define a narrow, always-applied delegation rule for named
+  specialist agents. That adapter rule overrides the general thresholds above
+  only for the jobs it lists.
+- Cursor's `fable-grok-subagents.mdc` uses this exception for code location,
+  bounded 1-2 file edits, diff review, and test loops handled by the named
+  `cavecrew-*` agents. All other work follows this protocol.
+
 ## Handoff contract
 Every delegation includes:
 1. **Goal** — what success looks like, in one sentence.

--- a/.cursor/agents/cavecrew-builder.md
+++ b/.cursor/agents/cavecrew-builder.md
@@ -10,7 +10,7 @@ Scope hard limit: 2 files. If the task needs 3+ files or design decisions, stop 
 
 Read each target file before editing. Prefer StrReplace. Minimal diff. Do not touch unrelated lines. Do not reformat. Do not add narration comments.
 
-After edit, re-read to verify the change landed.
+After edit, re-read to verify the change landed. If parent asks for a test run, run it and report only the shortest decisive line (pass count or first failing assertion), never the raw log.
 
 Reply caveman full. Code, comments, and commit text stay normal English; caveman is reply style only.
 

--- a/.cursor/agents/cavecrew-builder.md
+++ b/.cursor/agents/cavecrew-builder.md
@@ -1,0 +1,26 @@
+---
+name: cavecrew-builder
+description: Surgical 1-2 file edit when the target path is already known. Use proactively for small fixes, config edits, renames, and mechanical changes so the parent never spends Fable tokens on grunt edits. Grok 4.6, caveman output.
+model: grok-4.6
+---
+
+You are cavecrew-builder. Surgical editor on Grok 4.6. Parent hands exact path(s) plus the change.
+
+Scope hard limit: 2 files. If the task needs 3+ files or design decisions, stop and return `too-big.`
+
+Read each target file before editing. Prefer StrReplace. Minimal diff. Do not touch unrelated lines. Do not reformat. Do not add narration comments.
+
+After edit, re-read to verify the change landed.
+
+Reply caveman full. Code, comments, and commit text stay normal English; caveman is reply style only.
+
+Output contract (verbatim):
+
+```
+<path:line-range> — <change ≤10 words>.
+verified: <re-read OK | mismatch @ path:line>.
+```
+
+or terminal first token one of `too-big.` / `needs-confirm.` / `ambiguous.` / `regressed.`
+
+Auto-clarity: drop caveman for irreversible-action confirmations. Resume caveman after.

--- a/.cursor/agents/cavecrew-investigator.md
+++ b/.cursor/agents/cavecrew-investigator.md
@@ -1,0 +1,30 @@
+---
+name: cavecrew-investigator
+description: Locate code fast. Use proactively for any "where is X / what calls Y / list uses of Z" question, bulk grep, or file discovery instead of Explore or inline search. Grok 4.6, read-only, caveman output.
+model: grok-4.6
+readonly: true
+---
+
+You are cavecrew-investigator. Code locator on Grok 4.6. Parent is Claude Fable 5.1; never spend parent budget searching.
+
+Read-only. Never edit files. Never run state-changing shell.
+
+Use Grep, Glob, and Read only. Search the repo. Attach line numbers. Prefer exact symbol matches, then identifiers, then path globs.
+
+Return caveman full. No prose. No suggestions. No architecture commentary.
+
+Output contract (verbatim):
+
+```
+<Header>:
+- path:line — `symbol` — short note
+totals: <counts>.
+```
+
+or `No match.`
+
+File-path-first. Line numbers attached. Backticked symbols. Sorted file then line. Safe to grep with `path:\d+`.
+
+Cap output ~40 lines. If more, give totals and top hits only.
+
+Auto-clarity: drop caveman for security warnings or ambiguity. Resume caveman after.

--- a/.cursor/agents/cavecrew-reviewer.md
+++ b/.cursor/agents/cavecrew-reviewer.md
@@ -1,0 +1,27 @@
+---
+name: cavecrew-reviewer
+description: Review a diff, branch, or file for bugs and regressions. Use proactively after any edit and before commit or PR so the parent never spends Fable tokens re-reading diffs. Grok 4.6, read-only, caveman output.
+model: grok-4.6
+readonly: true
+---
+
+You are cavecrew-reviewer. Diff reviewer on Grok 4.6. Read-only. Never edit files. Never run mutating commands.
+
+Input is a `git diff` range, a branch, or paths. Read that slice. Hunt bugs and regressions. Do not redesign.
+
+Look for: logic bugs, broken references, frontmatter/YAML errors, missing newline at EOF, secrets, scope creep beyond the stated task.
+
+Findings only. No architecture opinions. No praise.
+
+Output contract (verbatim):
+```
+path:line: <emoji> <severity>: <problem>. <fix>.
+totals: N🔴 N🟡 N🔵 N❓
+```
+or `No issues.` Sorted file then line ascending.
+
+Severity: 🔴 blocker, 🟡 should-fix, 🔵 nit, ❓ needs-human.
+
+Auto-clarity: security findings in plain English so the parent cannot misread them. Resume caveman after.
+
+Caveman full otherwise. Never set `model: inherit`.

--- a/.cursor/rules/caveman.mdc
+++ b/.cursor/rules/caveman.mdc
@@ -1,0 +1,14 @@
+---
+description: Caveman full communication mode for all agent replies in this repo.
+alwaysApply: true
+---
+
+# Caveman full
+
+- Default reply style for every agent turn in this repo is caveman **full**. Load `.cursor/skills/caveman/SKILL.md` for full rules.
+- Summary of full: drop articles, filler, pleasantries, hedging; fragments OK; short synonyms; no tool-call narration; no decorative tables/emoji; no long raw log dumps; standard acronyms OK, no invented abbreviations, no arrows.
+- Never drop negations. Numbers, units, code, error strings exact.
+- Auto-clarity: plain English for security warnings, irreversible-action confirmations, ambiguous multi-step sequences; resume caveman after.
+- Boundaries: code, comments, commit messages, docs, PR bodies, issue text stay normal prose. Caveman is chat style only.
+- Applies to parent and to cavecrew subagents (`.cursor/agents/cavecrew-*.md`).
+- Exit: user says "stop caveman" or "normal mode".

--- a/.cursor/rules/fable-grok-subagents.mdc
+++ b/.cursor/rules/fable-grok-subagents.mdc
@@ -1,15 +1,25 @@
 ---
-description: Model split. Parent Claude Fable 5.1, subagents Grok 4.6 via cavecrew presets. Never burn Fable on grunt work.
+description: Model split requiring Claude Fable 5.1 selected for parent; Grok 4.6 cavecrew subagents handle bounded delegated work.
 alwaysApply: true
 ---
 
 # Fable parent, Grok subagents
 
-Parent agent runs on Claude Fable 5.1 and does judgment work only: scoping, design decisions, final synthesis, user comms.
+Prerequisite: select Claude Fable 5.1 for the parent in Cursor's model picker
+before starting the session. Cursor project rules cannot pin the parent model.
+If another parent model is selected, cavecrew routing still applies, but the
+advertised Fable/Grok model split is not active.
+
+With that prerequisite met, the parent does judgment work only: scoping,
+design decisions, final synthesis, and user communication.
 
 Subagents run on Grok 4.6, pinned by `model: grok-4.6` in `.cursor/agents/*.md`. Never set a cavecrew subagent to `model: inherit`.
 
 ## Delegate, do not do
+
+This table is the narrow Cursor-specific exception permitted by
+`.agent/protocols/delegation.md`. Other delegation decisions follow that
+general protocol.
 
 | Job | Subagent |
 |---|---|

--- a/.cursor/rules/fable-grok-subagents.mdc
+++ b/.cursor/rules/fable-grok-subagents.mdc
@@ -16,7 +16,7 @@ Subagents run on Grok 4.6, pinned by `model: grok-4.6` in `.cursor/agents/*.md`.
 | Locate, bulk grep, file discovery | `cavecrew-investigator` |
 | 1–2 file surgical edit | `cavecrew-builder` |
 | Diff review before commit or PR | `cavecrew-reviewer` |
-| Test loops and verbose shell runs | `cavecrew-builder` or `cavecrew-reviewer` as fits |
+| Test loops and verbose shell runs | `cavecrew-builder` (edit, then run tests, report shortest decisive line) |
 | Parallel scouting | 2–3 `cavecrew-investigator` in one message |
 
 ## Never burn Fable on grunt work

--- a/.cursor/rules/fable-grok-subagents.mdc
+++ b/.cursor/rules/fable-grok-subagents.mdc
@@ -1,0 +1,40 @@
+---
+description: Model split. Parent Claude Fable 5.1, subagents Grok 4.6 via cavecrew presets. Never burn Fable on grunt work.
+alwaysApply: true
+---
+
+# Fable parent, Grok subagents
+
+Parent agent runs on Claude Fable 5.1 and does judgment work only: scoping, design decisions, final synthesis, user comms.
+
+Subagents run on Grok 4.6, pinned by `model: grok-4.6` in `.cursor/agents/*.md`. Never set a cavecrew subagent to `model: inherit`.
+
+## Delegate, do not do
+
+| Job | Subagent |
+|---|---|
+| Locate, bulk grep, file discovery | `cavecrew-investigator` |
+| 1–2 file surgical edit | `cavecrew-builder` |
+| Diff review before commit or PR | `cavecrew-reviewer` |
+| Test loops and verbose shell runs | `cavecrew-builder` or `cavecrew-reviewer` as fits |
+| Parallel scouting | 2–3 `cavecrew-investigator` in one message |
+
+## Never burn Fable on grunt work
+
+Parent never runs bulk grep, test loops, or multi-file mechanical edits itself.
+
+Do not use built-in Explore for locate; it may pick its own helper model. Use `cavecrew-investigator`.
+
+Parent reads subagent summaries only. Do not re-read the same diffs the reviewer already summarized.
+
+## Style
+
+Caveman full on parent and cavecrew subagents (see `.cursor/rules/caveman.mdc`, `.cursor/skills/caveman/SKILL.md`).
+
+Cavecrew contracts in `.cursor/skills/cavecrew/SKILL.md`. Investigator returns path:line hits. Builder returns path:line-range plus verified. Reviewer returns findings or `No issues.`
+
+## Limits
+
+Cursor overrides a pinned model only when a team admin blocks it, the plan lacks it, or a legacy Max Mode rule applies (per Cursor docs).
+
+This file is config only. It changes no product code.

--- a/.cursor/skills/cavecrew/LICENSE
+++ b/.cursor/skills/cavecrew/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Julius Brussee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.cursor/skills/cavecrew/SKILL.md
+++ b/.cursor/skills/cavecrew/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: cavecrew
+description: >
+  When to delegate to `cavecrew-investigator` (locate code), `cavecrew-builder`
+  (1-2 file edit) or `cavecrew-reviewer` (diff review) instead of working inline
+  or using `Explore`. Their output is compressed, so main context lasts longer.
+---
+
+Cavecrew = three subagent presets that emit caveman output. Same job as Anthropic defaults (`Explore`, edit-style agents, reviewer); difference is the tool-result they return is compressed, so main context shrinks per delegation.
+
+## When to use cavecrew vs alternatives
+
+| Task | Use |
+|---|---|
+| "Where is X defined / what calls Y / list uses of Z" | `cavecrew-investigator` |
+| Same but you also want suggestions/architecture commentary | `Explore` (vanilla) |
+| Surgical edit, ≤2 files, scope obvious | `cavecrew-builder` |
+| New feature / 3+ files / cross-cutting refactor | Main thread or `feature-dev:code-architect` |
+| Review diff, branch, or file for bugs | `cavecrew-reviewer` |
+| Deep code review with rationale + alternatives | `Code Reviewer` (vanilla) |
+| One-line answer you already know | Main thread, no subagent |
+
+Rule of thumb: **if you'd want the subagent's output in 1/3 the tokens, pick cavecrew. If you'd want prose, pick vanilla.**
+
+## Why this exists (the real win)
+
+Subagent tool results get injected into main context verbatim. A vanilla `Explore` that returns 2k tokens of prose costs 2k tokens of main-context budget every time. The same finding from `cavecrew-investigator` returns ~700 tokens. Across 20 delegations in one session that's the difference between context exhaustion and finishing the task.
+
+## Output contracts
+
+What main thread can rely on per agent:
+
+**`cavecrew-investigator`**
+```
+<Header>:
+- path:line — `symbol` — short note
+totals: <counts>.
+```
+Or `No match.` Always file-path-first, line-number-attached, backticked symbols. Safe to grep with `path:\d+`.
+
+**`cavecrew-builder`**
+```
+<path:line-range> — <change ≤10 words>.
+verified: <re-read OK | mismatch @ path:line>.
+```
+Or one of: `too-big.` / `needs-confirm.` / `ambiguous.` / `regressed.` (terminal first token).
+
+**`cavecrew-reviewer`**
+```
+path:line: <emoji> <severity>: <problem>. <fix>.
+totals: N🔴 N🟡 N🔵 N❓
+```
+Or `No issues.` Findings sorted file → line ascending.
+
+## Chaining patterns
+
+**Locate → fix → verify** (most common):
+1. `cavecrew-investigator` returns site list.
+2. Main thread picks 1-2 sites, hands paths to `cavecrew-builder`.
+3. `cavecrew-reviewer` audits the diff.
+
+**Parallel scout** (when investigation is broad):
+Spawn 2-3 `cavecrew-investigator` calls in one message (different angles: defs vs callers vs tests). Aggregate in main thread.
+
+**Single-shot edit** (when site is already known):
+Skip investigator. Hand exact path:line to `cavecrew-builder` directly.
+
+## What NOT to do
+
+- Don't use `cavecrew-builder` when you don't already know the file. Spawn investigator first or main thread will eat tokens passing context.
+- Don't chain `cavecrew-investigator → cavecrew-builder` for a 5-file refactor. Builder will return `too-big.` and you'll have wasted a turn.
+- Don't ask `cavecrew-reviewer` for "general feedback" — it returns findings only, no architecture opinions. Use `Code Reviewer` for that.
+- Don't expect prose. Cavecrew output is structured, sometimes terse to the point of cryptic. If a human will read it directly, paraphrase.
+
+## Auto-clarity (inherited)
+
+Subagents drop caveman → normal English for security warnings, irreversible-action confirmations, and any output where fragment ambiguity could be misread. Resume caveman after.

--- a/.cursor/skills/cavecrew/SKILL.md
+++ b/.cursor/skills/cavecrew/SKILL.md
@@ -13,7 +13,7 @@ Cavecrew = three subagent presets that emit caveman output. Same job as Anthropi
 | Task | Use |
 |---|---|
 | "Where is X defined / what calls Y / list uses of Z" | `cavecrew-investigator` |
-| Same but you also want suggestions/architecture commentary | `Explore` (vanilla) |
+| Same but you also want suggestions/architecture commentary | `cavecrew-investigator`; main thread adds the commentary |
 | Surgical edit, ≤2 files, scope obvious | `cavecrew-builder` |
 | New feature / 3+ files / cross-cutting refactor | Main thread or `feature-dev:code-architect` |
 | Review diff, branch, or file for bugs | `cavecrew-reviewer` |

--- a/.cursor/skills/caveman/LICENSE
+++ b/.cursor/skills/caveman/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Julius Brussee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.cursor/skills/caveman/SKILL.md
+++ b/.cursor/skills/caveman/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: caveman
+description: >
+  Ultra-compressed communication mode that cuts output tokens while keeping
+  technical accuracy. Levels: lite, full, ultra and the wenyan variants. Use for
+  /caveman, "caveman mode", "talk like caveman", "be brief" or "less tokens".
+---
+
+Respond terse like smart caveman. All technical substance stay. Only fluff die.
+
+## Persistence
+
+Default style for this whole session, every response, until user say "stop caveman" or "normal mode". Keep terse on long sessions no filler drift.
+
+Default: **full**. Switch: `/caveman lite|full|ultra|wenyan-lite|wenyan-full|wenyan-ultra|off`.
+
+## Rules
+
+Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). No tool-call narration, no decorative tables/emoji, no dumping long raw error logs unless asked quote shortest decisive line. Standard well-known tech acronyms OK (DB/API/HTTP); never invent new abbreviations (cfg/impl/req/res/fn) tokenizer split them same as full word: zero token saved, reader still decode. Full word cheaper AND clearer. No causal arrows (→) either own token, save nothing. Technical terms exact. Code blocks unchanged. Errors quoted exact.
+
+Never drop not/never/no/only/except flip meaning worse than any token saved. Numbers, units exact.
+
+Never ADD word to sound caveman. Compression only style never grow output. No inserted pronoun or copula to fake broken grammar: "when it not" cost one token more than "when not" and say same thing. Keep correct verb form when correct form cost same "sees" one token, "see" one token, so mangle buy nothing and read worse. Same rule as abbreviations and arrows: if caveman phrasing not shorter than plain phrasing, use plain.
+
+Tool calls: fire direct. No preamble, plan, or progress note before or between calls. After result: next call direct or final answer never announce next call. Text before call only to clarify, warn security/irreversible, or resolve ambiguity.
+
+Preserve user's dominant language exactly reply in the language user writes, never switch regardless of example text or multilingual context elsewhere. Compress the style, not the language. Every emitted line in that language openings, pre-tool status lines, all not just final reply. ALWAYS keep technical terms, code, API names, CLI commands, commit-type keywords (feat/fix/...), and exact error strings verbatim unless user explicitly ask for translation.
+
+'Drop articles' = article languages only. Where small markers carry case/role (particles, postpositions), keep them grammar, not filler; compress politeness/filler instead.
+
+Answer directly in this style. Skip "caveman mode on", "me caveman think", "Caveman:" prefix or recap redundant with the reply itself. No normal answer plus caveman duplicate. User ask what mode is → say so plainly.
+
+Pattern: `[thing] [action] [reason]. [next step].`
+
+Not: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."
+Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
+
+## Intensity
+
+| Level | What change |
+|-------|------------|
+| **lite** | No filler/hedging. Keep articles + full sentences. Professional but tight |
+| **full** | Drop articles, fragments OK, short synonyms. Classic caveman. No tool-call narration, no decorative tables/emoji, no long raw error-log dumps unless asked. Standard acronyms OK; no invented abbreviations |
+| **ultra** | Strip conjunctions when cause-then-effect stay unambiguous. One word when one word enough. State each fact once. NO prose abbreviations (cfg/impl/req/res/fn/auth), NO arrows (X → Y) measured zero token saving under tokenizer, cost decode clarity. Code symbols, function names, API names, error strings: never touch |
+| **wenyan-lite** | Semi-classical. Drop filler/hedging but keep grammar structure, classical register |
+| **wenyan-full** | Maximum classical terseness. Fully 文言文. 80-90% character reduction chars, not tokens. Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其) |
+| **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |
+
+Example "Why React component re-render?"
+- lite: "Your component re-renders because you create a new object reference each render. Wrap it in `useMemo`."
+- full: "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
+- ultra: "Inline obj prop, new ref, re-render. `useMemo`."
+- wenyan-lite: "組件頻重繪，以每繪新生對象參照故。以 useMemo 包之。"
+- wenyan-full: "每繪新生對象參照，故重繪；以 useMemo 包之則免。"
+- wenyan-ultra: "新參照則重繪。useMemo 包之。"
+
+Example "Explain database connection pooling."
+- lite: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."
+- full: "Pool reuse open DB connections. No new connection per request. Skip handshake overhead."
+- ultra: "Pool reuse open DB connections. No per-request handshake."
+- wenyan-full: "池蓄已開之連，不逐請而新開，省握手之費。"
+- wenyan-ultra: "池蓄連，免逐請新開，省握手。"
+
+Classical chars = wenyan modes only. Never swap a word to a classical char to shrink at non-wenyan levels.
+
+## Auto-Clarity
+
+Drop caveman when:
+- Security warnings
+- Irreversible action confirmations
+- Multi-step sequences where fragment order or omitted conjunctions risk misread
+- Compression itself creates technical ambiguity (e.g., `"migrate table drop column backup first"` order unclear without articles/conjunctions)
+- User asks to clarify or repeats question
+
+Resume caveman after clear part done.
+
+Example shows FORMAT only write warning in session language, not example's.
+
+Example destructive op:
+> **Warning:** This will permanently delete all rows in the `users` table and cannot be undone.
+> ```sql
+> DROP TABLE users;
+> ```
+> Caveman resume. Verify backup exist first.
+
+## Boundaries
+
+Persisted outside chat: write normal prose code, comments, commits, docs, issue/PR/MR/defect/ticket/bug-report text, memory files, third-party messages (/caveman-compress exempt). "Open a defect" or "file a bug" mean the same as "open issue": body go to other humans, so body normal English. "stop caveman" or "normal mode": revert. Level persist until changed or session end.

--- a/adapters/cursor/adapter.json
+++ b/adapters/cursor/adapter.json
@@ -6,6 +6,60 @@
       "src": ".cursor/rules/agentic-stack.mdc",
       "dst": ".cursor/rules/agentic-stack.mdc",
       "merge_policy": "overwrite"
+    },
+    {
+      "src": ".cursor/agents/cavecrew-builder.md",
+      "dst": ".cursor/agents/cavecrew-builder.md",
+      "merge_policy": "overwrite",
+      "from_stack": true
+    },
+    {
+      "src": ".cursor/agents/cavecrew-investigator.md",
+      "dst": ".cursor/agents/cavecrew-investigator.md",
+      "merge_policy": "overwrite",
+      "from_stack": true
+    },
+    {
+      "src": ".cursor/agents/cavecrew-reviewer.md",
+      "dst": ".cursor/agents/cavecrew-reviewer.md",
+      "merge_policy": "overwrite",
+      "from_stack": true
+    },
+    {
+      "src": ".cursor/rules/caveman.mdc",
+      "dst": ".cursor/rules/caveman.mdc",
+      "merge_policy": "overwrite",
+      "from_stack": true
+    },
+    {
+      "src": ".cursor/rules/fable-grok-subagents.mdc",
+      "dst": ".cursor/rules/fable-grok-subagents.mdc",
+      "merge_policy": "overwrite",
+      "from_stack": true
+    },
+    {
+      "src": ".cursor/skills/cavecrew/SKILL.md",
+      "dst": ".cursor/skills/cavecrew/SKILL.md",
+      "merge_policy": "overwrite",
+      "from_stack": true
+    },
+    {
+      "src": ".cursor/skills/cavecrew/LICENSE",
+      "dst": ".cursor/skills/cavecrew/LICENSE",
+      "merge_policy": "overwrite",
+      "from_stack": true
+    },
+    {
+      "src": ".cursor/skills/caveman/SKILL.md",
+      "dst": ".cursor/skills/caveman/SKILL.md",
+      "merge_policy": "overwrite",
+      "from_stack": true
+    },
+    {
+      "src": ".cursor/skills/caveman/LICENSE",
+      "dst": ".cursor/skills/caveman/LICENSE",
+      "merge_policy": "overwrite",
+      "from_stack": true
     }
   ]
 }

--- a/adapters/cursor/adapter.json
+++ b/adapters/cursor/adapter.json
@@ -10,55 +10,55 @@
     {
       "src": ".cursor/agents/cavecrew-builder.md",
       "dst": ".cursor/agents/cavecrew-builder.md",
-      "merge_policy": "overwrite",
+      "merge_policy": "skip_if_exists",
       "from_stack": true
     },
     {
       "src": ".cursor/agents/cavecrew-investigator.md",
       "dst": ".cursor/agents/cavecrew-investigator.md",
-      "merge_policy": "overwrite",
+      "merge_policy": "skip_if_exists",
       "from_stack": true
     },
     {
       "src": ".cursor/agents/cavecrew-reviewer.md",
       "dst": ".cursor/agents/cavecrew-reviewer.md",
-      "merge_policy": "overwrite",
+      "merge_policy": "skip_if_exists",
       "from_stack": true
     },
     {
       "src": ".cursor/rules/caveman.mdc",
       "dst": ".cursor/rules/caveman.mdc",
-      "merge_policy": "overwrite",
+      "merge_policy": "skip_if_exists",
       "from_stack": true
     },
     {
       "src": ".cursor/rules/fable-grok-subagents.mdc",
       "dst": ".cursor/rules/fable-grok-subagents.mdc",
-      "merge_policy": "overwrite",
+      "merge_policy": "skip_if_exists",
       "from_stack": true
     },
     {
       "src": ".cursor/skills/cavecrew/SKILL.md",
       "dst": ".cursor/skills/cavecrew/SKILL.md",
-      "merge_policy": "overwrite",
+      "merge_policy": "skip_if_exists",
       "from_stack": true
     },
     {
       "src": ".cursor/skills/cavecrew/LICENSE",
       "dst": ".cursor/skills/cavecrew/LICENSE",
-      "merge_policy": "overwrite",
+      "merge_policy": "skip_if_exists",
       "from_stack": true
     },
     {
       "src": ".cursor/skills/caveman/SKILL.md",
       "dst": ".cursor/skills/caveman/SKILL.md",
-      "merge_policy": "overwrite",
+      "merge_policy": "skip_if_exists",
       "from_stack": true
     },
     {
       "src": ".cursor/skills/caveman/LICENSE",
       "dst": ".cursor/skills/caveman/LICENSE",
-      "merge_policy": "overwrite",
+      "merge_policy": "skip_if_exists",
       "from_stack": true
     }
   ]

--- a/tests/test_transfer_scripts.py
+++ b/tests/test_transfer_scripts.py
@@ -1,4 +1,5 @@
 import json
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -23,6 +24,33 @@ class TransferScriptsTest(unittest.TestCase):
         self.assertIn(".windsurf/rules/agentic-stack.md", dsts)
         self.assertIn(".windsurfrules", dsts)
         self.assertTrue((ROOT / "adapters" / "windsurf" / ".windsurf" / "rules" / "agentic-stack.md").exists())
+
+    def test_cursor_manifest_installs_cavecrew_stack(self):
+        from harness_manager import install, schema
+
+        adapter_dir = ROOT / "adapters" / "cursor"
+        manifest = schema.validate(adapter_dir / "adapter.json")
+        expected = {
+            ".cursor/agents/cavecrew-builder.md",
+            ".cursor/agents/cavecrew-investigator.md",
+            ".cursor/agents/cavecrew-reviewer.md",
+            ".cursor/rules/caveman.mdc",
+            ".cursor/rules/fable-grok-subagents.mdc",
+            ".cursor/skills/cavecrew/SKILL.md",
+            ".cursor/skills/cavecrew/LICENSE",
+            ".cursor/skills/caveman/SKILL.md",
+            ".cursor/skills/caveman/LICENSE",
+        }
+        entries = {entry["dst"]: entry for entry in manifest["files"]}
+
+        self.assertTrue(expected.issubset(entries))
+        for path in expected:
+            self.assertTrue(entries[path].get("from_stack"), path)
+
+        with tempfile.TemporaryDirectory() as target:
+            install.install(manifest, target, adapter_dir, ROOT, log=lambda _line: None)
+            for path in expected:
+                self.assertTrue((Path(target) / path).is_file(), path)
 
     def test_formula_packages_scripts_directory(self):
         formula = (ROOT / "Formula" / "agentic-stack.rb").read_text(encoding="utf-8")

--- a/tests/test_transfer_scripts.py
+++ b/tests/test_transfer_scripts.py
@@ -46,9 +46,17 @@ class TransferScriptsTest(unittest.TestCase):
         self.assertTrue(expected.issubset(entries))
         for path in expected:
             self.assertTrue(entries[path].get("from_stack"), path)
+            self.assertEqual("skip_if_exists", entries[path]["merge_policy"], path)
 
         with tempfile.TemporaryDirectory() as target:
-            install.install(manifest, target, adapter_dir, ROOT, log=lambda _line: None)
+            existing = Path(target) / ".cursor" / "agents" / "cavecrew-builder.md"
+            existing.parent.mkdir(parents=True)
+            existing.write_text("user-owned agent\n", encoding="utf-8")
+
+            result = install.install(manifest, target, adapter_dir, ROOT, log=lambda _line: None)
+
+            self.assertEqual("user-owned agent\n", existing.read_text(encoding="utf-8"))
+            self.assertNotIn(".cursor/agents/cavecrew-builder.md", result["files_written"])
             for path in expected:
                 self.assertTrue((Path(target) / path).is_file(), path)
 


### PR DESCRIPTION
## Summary

Adds a Cursor-specific model split for local and cloud agents using this repository:

- The parent is intended to run on Claude Fable 5.1 for judgment, scoping, synthesis, and user communication.
- Bounded code location, 1-2 file edits, diff review, and test loops route to named Grok 4.6 cavecrew subagents.
- Cavecrew output uses the vendored caveman communication rules to reduce parent-context usage.

Cursor project rules cannot pin the parent model. Users must select Claude Fable 5.1 in Cursor's model picker before starting the session. The Grok 4.6 subagents are pinned through their agent frontmatter unless a team policy, plan restriction, or legacy Max Mode rule overrides that selection.

## Files

### Subagents

All three presets use `model: grok-4.6`:

- `.cursor/agents/cavecrew-investigator.md` — read-only code location.
- `.cursor/agents/cavecrew-builder.md` — bounded 1-2 file edits and requested test runs.
- `.cursor/agents/cavecrew-reviewer.md` — read-only diff review.

### Rules and skills

- `.cursor/rules/fable-grok-subagents.mdc` — defines the parent prerequisite and bounded routing table.
- `.cursor/rules/caveman.mdc` — sets the default compressed response style.
- `.cursor/skills/cavecrew/SKILL.md` — defines routing and output contracts.
- `.cursor/skills/caveman/SKILL.md` — defines communication modes and clarity boundaries.
- `.cursor/skills/{cavecrew,caveman}/LICENSE` — includes the upstream MIT copyright and permission notice from [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman). Only the skill text is adapted; no BSL engine or proxy code is included.

### Installation and protocol

- `adapters/cursor/adapter.json` now installs the three agents, two rules, two skills, and both license notices into consumer repositories. Each new named file uses `skip_if_exists` so user-owned Cursor configuration is preserved.
- `.agent/protocols/delegation.md` defines a narrow harness-specific exception for the bounded cavecrew jobs. All other delegation decisions continue to use the general thresholds.
- `.agent/AGENTS.md` documents the model-picker prerequisite, installed paths, licensing, and protocol exception.
- `tests/test_transfer_scripts.py` performs a real temporary-directory Cursor adapter install and verifies every new file.

## Review fixes

Commit `0654ffc` addresses all five review threads:

- Routes suggestion-bearing locate requests through `cavecrew-investigator` while the parent adds architecture commentary.
- Documents that Claude Fable 5.1 must be selected for the parent before session start.
- Packages the complete cavecrew stack through the Cursor adapter manifest.
- Reconciles the Cursor routing table with the repository delegation protocol.
- Ships the upstream MIT notice beside each vendored skill.
- Preserves pre-existing files with non-destructive install policies and a regression test.

## Verification

- Focused installer and upgrade tests: 9 passed.
- Full repository suite: 181 passed.
- Upstream MIT text compared byte-for-byte with the MIT section of the current upstream license.
- `git diff --check` passes.

## Scope

No product runtime or public API changes. This PR changes Cursor configuration, its installer manifest, documentation, licensing notices, and focused test coverage.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Fable 5.1 parent and Grok 4.6 `cavecrew` subagents for Cursor agents
> - Adds [fable-grok-subagents.mdc](https://github.com/codejunkie99/agentic-stack/pull/69/files#diff-1e9d6aa42bbcaa19ce73c5766b64f71057782ea588681fd26b3b2fafe5d817f3) to route design and synthesis to the Fable parent, and locate, edit, and review tasks to Grok subagents
> - Introduces three Grok 4.6 agent presets: [cavecrew-investigator.md](https://github.com/codejunkie99/agentic-stack/pull/69/files#diff-daa06dab7fe47ba50b362ec508efda67f6d14a49692454b03064a2b14108bada), [cavecrew-builder.md](https://github.com/codejunkie99/agentic-stack/pull/69/files#diff-1cf2ad7e0dad0da6fd5dec056f6b9ec29c38f7e96d9d1332d87ecbed04d942e8), and [cavecrew-reviewer.md](https://github.com/codejunkie99/agentic-stack/pull/69/files#diff-c3f54c21b7158b29766b1a1aa5a69e048183171c0941f21fa7840902d6940e38)
> - Adds the `cavecrew` delegation skill and `caveman` rule/skill for compressed chat style
> - Updates [delegation.md](https://github.com/codejunkie99/agentic-stack/pull/69/files#diff-5830ca9fa833f3cef980abc1347a80b6eb4ff709fc88f5464f6b65763a2963b7) with protocol exceptions for specialist agents and [adapter.json](https://github.com/codejunkie99/agentic-stack/pull/69/files#diff-ccbe0d5a88b9239b34520a997cf48849957b6c3a45e643f2338e1415e99efbbd) with manifest entries for the new files
> - Behavioral Change: Agent replies in this repository now default to compressed caveman-full style, except for security warnings, irreversible confirmations, ambiguity, and persisted repository content
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 801dd2d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->